### PR TITLE
Add password on launcher

### DIFF
--- a/openpype/lib/local_settings.py
+++ b/openpype/lib/local_settings.py
@@ -572,14 +572,15 @@ def get_openpype_username():
     return username
 
 
-def is_admin_password_required():
+def is_admin_password_required(ignore_admin_skip=False):
     system_settings = get_system_settings()
     password = system_settings["general"].get("admin_password")
     if not password:
         return False
 
-    local_settings = get_local_settings()
-    is_admin = local_settings.get("general", {}).get("is_admin", False)
-    if is_admin:
-        return False
+    if ignore_admin_skip:
+        local_settings = get_local_settings()
+        is_admin = local_settings.get("general", {}).get("is_admin", False)
+        if is_admin:
+            return False
     return True

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -3,10 +3,17 @@ from openpype.modules import (
     ITrayAction,
 )
 
+from openpype.widgets import PasswordDialog
+from openpype.lib import is_admin_password_required
+
 
 class LauncherAction(OpenPypeModule, ITrayAction):
     label = "Launcher"
     name = "launcher_tool"
+
+    def __init__(self, manager, settings):
+        super(LauncherAction, self).__init__(manager, settings)
+        self._user_passed = False
 
     def initialize(self, _modules_settings):
         # This module is always enabled
@@ -42,6 +49,16 @@ class LauncherAction(OpenPypeModule, ITrayAction):
         self.show_launcher()
 
     def show_launcher(self):
+        if not self._user_passed:
+            self._user_passed = not is_admin_password_required()
+
+        if not self._user_passed:
+            dialog = PasswordDialog(allow_remember=False)
+            dialog.setModal(True)
+            dialog.exec_()
+            if not dialog.result():
+                return
+
         if self.window:
             self.window.show()
             self.window.raise_()

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -4,14 +4,12 @@ from openpype.modules import (
 )
 
 from openpype.widgets import PasswordDialog
+from openpype.lib import is_admin_password_required
 
 
 class LauncherAction(OpenPypeModule, ITrayAction):
     label = "Launcher"
     name = "launcher_tool"
-
-    def __init__(self, manager, settings):
-        super(LauncherAction, self).__init__(manager, settings)
 
     def initialize(self, _modules_settings):
         # This module is always enabled
@@ -47,11 +45,13 @@ class LauncherAction(OpenPypeModule, ITrayAction):
         self.show_launcher()
 
     def show_launcher(self):
-        dialog = PasswordDialog(allow_remember=False)
-        dialog.setModal(True)
-        dialog.exec_()
-        if not dialog.result():
-            return
+        password_required = is_admin_password_required(ignore_admin_skip=True)
+        if password_required:
+            dialog = PasswordDialog(allow_remember=False)
+            dialog.setModal(True)
+            dialog.exec_()
+            if not dialog.result():
+                return
 
         if self.window:
             self.window.show()

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -4,7 +4,6 @@ from openpype.modules import (
 )
 
 from openpype.widgets import PasswordDialog
-from openpype.lib import is_admin_password_required
 
 
 class LauncherAction(OpenPypeModule, ITrayAction):
@@ -13,7 +12,6 @@ class LauncherAction(OpenPypeModule, ITrayAction):
 
     def __init__(self, manager, settings):
         super(LauncherAction, self).__init__(manager, settings)
-        self._user_passed = False
 
     def initialize(self, _modules_settings):
         # This module is always enabled

--- a/openpype/modules/launcher_action.py
+++ b/openpype/modules/launcher_action.py
@@ -49,15 +49,11 @@ class LauncherAction(OpenPypeModule, ITrayAction):
         self.show_launcher()
 
     def show_launcher(self):
-        if not self._user_passed:
-            self._user_passed = not is_admin_password_required()
-
-        if not self._user_passed:
-            dialog = PasswordDialog(allow_remember=False)
-            dialog.setModal(True)
-            dialog.exec_()
-            if not dialog.result():
-                return
+        dialog = PasswordDialog(allow_remember=False)
+        dialog.setModal(True)
+        dialog.exec_()
+        if not dialog.result():
+            return
 
         if self.window:
             self.window.show()

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -273,6 +273,9 @@ class MainWidget(QtWidgets.QWidget):
         if self._password_dialog:
             return
 
+        if not self._user_passed:
+            self._user_passed = not is_admin_password_required(ignore_admin_skip=True)
+
         self._on_state_change()
 
         if not self._user_passed:

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -273,9 +273,6 @@ class MainWidget(QtWidgets.QWidget):
         if self._password_dialog:
             return
 
-        if not self._user_passed:
-            self._user_passed = not is_admin_password_required()
-
         self._on_state_change()
 
         if not self._user_passed:

--- a/openpype/tools/settings/settings/window.py
+++ b/openpype/tools/settings/settings/window.py
@@ -280,7 +280,7 @@ class MainWidget(QtWidgets.QWidget):
 
         if not self._user_passed:
             # Avoid doubled dialog
-            dialog = PasswordDialog(self)
+            dialog = PasswordDialog(self, allow_remember=False)
             dialog.setModal(True)
             dialog.finished.connect(self._on_password_dialog_close)
 
@@ -298,6 +298,9 @@ class MainWidget(QtWidgets.QWidget):
             tab_widget.reset()
         self._main_reset = False
         self._check_on_reset()
+
+        # This is to show password dialog each time settings are opened
+        self._user_passed = False
 
     def _update_search_dialog(self, clear=False):
         if self._search_dialog.isVisible():


### PR DESCRIPTION
## Changelog Description
Open the password dialog when launcher start if you have not the admin right

## Testing notes:
1. In your local settings make sure in the "General" Section that the 'Admin Permissions' checkbox is unchecked
2. Open Launcher
