### PR TITLE
Enhancement/60 enhancement publish a psd file to load in another task

### DIFF
--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -18,7 +18,7 @@ class FileLoader(api.AfterEffectsLoader):
                 "prerender",
                 "review",
                 "audio",
-                "review"]
+                "workfile"]
     representations = ["*"]
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -17,7 +17,8 @@ class FileLoader(api.AfterEffectsLoader):
                 "render",
                 "prerender",
                 "review",
-                "audio"]
+                "audio",
+                "review"]
     representations = ["*"]
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/openpype/hosts/photoshop/plugins/load/load_image.py
+++ b/openpype/hosts/photoshop/plugins/load/load_image.py
@@ -11,7 +11,7 @@ class ImageLoader(photoshop.PhotoshopLoader):
     Stores the imported asset in a container named after the asset.
     """
 
-    families = ["image", "render"]
+    families = ["image", "render", "workfile"]
     representations = ["*"]
 
     def load(self, context, name=None, namespace=None, data=None):


### PR DESCRIPTION
## Changelog Description
Add 'workfile' tags to supported families for both After Effects and Photoshop to enable `.psd` import function.

## Additional info
This feature seems to be natively supported by OpenPype, but tags were removed in an old commit without explication (see [corresponding ticket ](https://github.com/quadproduction/issue_tracker/issues/60) for more details).

Tag hasn't been added to tvPaint because it automatically creates a new incremented version, and it is not a desired behavior.

## Testing notes:
1. Launch After Effects or Photoshop
2. Import PSD file through import file (After Effects) or import image (Photoshop) action.

## Ticket
Closes quadproduction/issue_tracker#60