### PR TITLE
Apply handle to playback start and end frame

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2284,6 +2284,7 @@ def get_frame_range(include_animation_range=False):
         "handleStart": handle_start,
         "handleEnd": handle_end
     }
+
     if include_animation_range:
         # The animation range values are only included to define whether
         # the Maya time slider should include the handles or not.
@@ -2307,6 +2308,8 @@ def get_frame_range(include_animation_range=False):
             animation_start -= int(handle_start)
             animation_end += int(handle_end)
 
+        frame_range["frameStart"] = animation_start
+        frame_range["frameEnd"] = animation_end
         frame_range["animationStart"] = animation_start
         frame_range["animationEnd"] = animation_end
 


### PR DESCRIPTION
## Changelog Description
Include the handle frame data in Maya 'Openpype > Set Frame Range' 
Frame Start and Frame End are now set correct

## Testing notes:
1. Take a random Shot item in ftrack and set a custom handle, by example this [one](https://fixstudio.ftrackapp.com/#slideEntityId=d53abf32-bc3e-11ed-88a7-f201ae46d194&slideEntityType=task&view=tasks&itemId=projects&entityId=531e87c8-b913-11ed-88a7-f201ae46d194&entityType=task) 
2. Open Openpype and 
3.  Click on 'Openpype > Set Frame Range' 
4. Timeline should be set correctly (should be 51,51-160,160)