### PR TITLE
Add try except for OIIO command

### DIFF
--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -102,8 +102,8 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 colorspace_data = repre["colorspaceData"]
                 source_colorspace = colorspace_data["colorspace"]
                 config_path = colorspace_data.get("config", {}).get("path")
-                display = colorspace_data["display"]
-                view = colorspace_data["view"]
+                display = colorspace_data.get("display")
+                view = colorspace_data.get("view")
                 try:
                     thumbnail_created = self.create_thumbnail_oiio(
                         full_input_path,

--- a/openpype/plugins/publish/extract_thumbnail.py
+++ b/openpype/plugins/publish/extract_thumbnail.py
@@ -104,14 +104,20 @@ class ExtractThumbnail(pyblish.api.InstancePlugin):
                 config_path = colorspace_data.get("config", {}).get("path")
                 display = colorspace_data["display"]
                 view = colorspace_data["view"]
-                thumbnail_created = self.create_thumbnail_oiio(
-                    full_input_path,
-                    full_output_path,
-                    config_path,
-                    source_colorspace,
-                    display,
-                    view
-                )
+                try:
+                    thumbnail_created = self.create_thumbnail_oiio(
+                        full_input_path,
+                        full_output_path,
+                        config_path,
+                        source_colorspace,
+                        display,
+                        view
+                    )
+                except Exception as e:
+                    self.log.debug((
+                        "Converting with OIIO failed "
+                        "with the following error {}".format(e)
+                    ))
 
             # Try to use FFMPEG if OIIO is not supported or for cases when
             #    oiiotool isn't available

--- a/openpype/plugins/publish/extract_thumbnail_from_source.py
+++ b/openpype/plugins/publish/extract_thumbnail_from_source.py
@@ -107,9 +107,15 @@ class ExtractThumbnailFromSource(pyblish.api.InstancePlugin):
             self.log.debug("Trying to convert with OIIO")
             # If the input can read by OIIO then use OIIO method for
             # conversion otherwise use ffmpeg
-            thumbnail_created = self.create_thumbnail_oiio(
-                thumbnail_source, full_output_path
-            )
+            try:
+                thumbnail_created = self.create_thumbnail_oiio(
+                    thumbnail_source, full_output_path
+                )
+            except Exception as e:
+                self.log.debug((
+                    "Converting with OIIO failed "
+                    "with the following error {}".format(e)
+                ))
 
         # Try to use FFMPEG if OIIO is not supported or for cases when
         #    oiiotool isn't available


### PR DESCRIPTION
## Changelog Description
Let run FFMPEG command if OIIO command crashed.


## Testing notes:
1. Publish a sequence (Enable the Review) with Nuke on the farm. 
2. Verify if ExtractThumbnail plugin do his job.
