### PR TITLE
Resolve slow oiiotool transcode process

### DIFF
--- a/openpype/plugins/publish/extract_color_transcode.py
+++ b/openpype/plugins/publish/extract_color_transcode.py
@@ -158,7 +158,8 @@ class ExtractOIIOTranscode(publish.Extractor):
                         view,
                         display,
                         additional_command_args,
-                        self.log
+                        self.log,
+                        input_args=["-i:ch=R,G,B"]
                     )
 
                 # cleanup temporary transcoded files


### PR DESCRIPTION
## Changelog Description
Limit input channels for oiiotool command to speed up transcode process.

## Testing notes:
1. On Maya, publish a render on the farm.
2. Verify if the publish job do not take long time to publish. 

- Note that you can not test the code on the farm. When you have the render job done, you can suspend the publish job, and run this command at the Openpype repository that do the publish (Modify the `json` path based on your current project and shot)
```
time poetry run python start.py --headless publish /prod/project/CARTIER_ODYSSEE_CNY_23_41/5_FILM/Shots/800_0010/work/light/renders/maya/800_0010_workfileLight_v002/MasterLayer/MasterLayer_metadata.json --targets deadline --targets farm
```
