### PR TITLE
Enhancement/152 simplify playblasterreviewer creator for tvpaint

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -20,7 +20,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
         elif creator_identifier == "render.pass":
             self._collect_data_for_render_pass(instance)
 
-        elif creator_identifier == "render.scene":
+        elif creator_identifier in ["render.scene", "render.playblast"]:
             self._collect_data_for_render_scene(instance)
 
         else:
@@ -100,13 +100,14 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
             instance.context.data["layersData"]
         )
 
-        render_pass_name = (
-            instance.data["creator_attributes"]["render_pass_name"]
-        )
-        subset_name = instance.data["subset"]
-        instance.data["subset"] = subset_name.format(
-            **prepare_template_data({"renderpass": render_pass_name})
-        )
+        if instance.data["creator_attributes"].get('render_pass_name'):
+            render_pass_name = (
+                instance.data["creator_attributes"]["render_pass_name"]
+            )
+            subset_name = instance.data["subset"]
+            instance.data["subset"] = subset_name.format(
+                **prepare_template_data({"renderpass": render_pass_name})
+            )
 
     def _collect_data_for_review(self, instance):
         instance.data["layers"] = copy.deepcopy(

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -31,6 +31,11 @@ class ExtractSequence(pyblish.api.Extractor):
     review_bg = [255, 255, 255, 255]
 
     def process(self, instance):
+        print('###\n####\n###')
+        print(ExtractSequence)
+        print('###\n####\n###')
+        self.log.debug(instance.data['family'])
+        self.log.debug(instance.data['families'])
         self.log.info(
             "* Processing instance \"{}\"".format(instance.data["label"])
         )
@@ -62,7 +67,9 @@ class ExtractSequence(pyblish.api.Extractor):
         ignore_layers_transparency = instance.data.get(
             "ignoreLayersTransparency", False
         )
+        print(instance.context.data)
 
+        print(instance.data)
         family_lowered = instance.data["family"].lower()
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.context.data["sceneMarkOut"]
@@ -111,9 +118,16 @@ class ExtractSequence(pyblish.api.Extractor):
             "Files will be rendered to folder: {}".format(output_dir)
         )
 
-        if instance.data["family"] == "review":
+        export_type = instance.data["creator_attributes"].get("export_type", "project")
+        print('####\n###\n### EXPORT TYPE')
+        print(export_type)
+        print('####\n###\n###')
+
+        is_review = instance.data["family"] == "review"
+        is_playblast = instance.data["creator_identifier"] == "render.playblast"
+        if is_review or is_playblast:
             result = self.render_review(
-                output_dir, mark_in, mark_out, scene_bg_color
+                output_dir, export_type, mark_in, mark_out, scene_bg_color
             )
         else:
             # Render output
@@ -204,7 +218,7 @@ class ExtractSequence(pyblish.api.Extractor):
         return repre_filenames
 
     def render_review(
-        self, output_dir, mark_in, mark_out, scene_bg_color
+        self, output_dir, export_type, mark_in, mark_out, scene_bg_color
     ):
         """ Export images from TVPaint using `tv_savesequence` command.
 
@@ -236,12 +250,16 @@ class ExtractSequence(pyblish.api.Extractor):
             "export_path = \"{}\"".format(
                 first_frame_filepath.replace("\\", "/")
             ),
-            "tv_savesequence '\"'export_path'\"' {} {}".format(
-                mark_in, mark_out
+            "tv_projectsavesequence '\"'export_path'\"' \"{}\" {} {}".format(
+                export_type, mark_in, mark_out
             )
         ]
+        print('####\n###\n### CMD')
+        print(george_script_lines)
+        print('####\n###\n###')
+
         if scene_bg_color:
-            # Change bg color back to previous scene bg color
+            # Change bg color back to previous scene bg colorq
             _scene_bg_color = copy.deepcopy(scene_bg_color)
             bg_type = _scene_bg_color.pop(0)
             orig_color_command = [

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -31,11 +31,6 @@ class ExtractSequence(pyblish.api.Extractor):
     review_bg = [255, 255, 255, 255]
 
     def process(self, instance):
-        print('###\n####\n###')
-        print(ExtractSequence)
-        print('###\n####\n###')
-        self.log.debug(instance.data['family'])
-        self.log.debug(instance.data['families'])
         self.log.info(
             "* Processing instance \"{}\"".format(instance.data["label"])
         )
@@ -67,9 +62,7 @@ class ExtractSequence(pyblish.api.Extractor):
         ignore_layers_transparency = instance.data.get(
             "ignoreLayersTransparency", False
         )
-        print(instance.context.data)
 
-        print(instance.data)
         family_lowered = instance.data["family"].lower()
         mark_in = instance.context.data["sceneMarkIn"]
         mark_out = instance.context.data["sceneMarkOut"]
@@ -119,9 +112,6 @@ class ExtractSequence(pyblish.api.Extractor):
         )
 
         export_type = instance.data["creator_attributes"].get("export_type", "project")
-        print('####\n###\n### EXPORT TYPE')
-        print(export_type)
-        print('####\n###\n###')
 
         is_review = instance.data["family"] == "review"
         is_playblast = instance.data["creator_identifier"] == "render.playblast"
@@ -254,9 +244,6 @@ class ExtractSequence(pyblish.api.Extractor):
                 export_type, mark_in, mark_out
             )
         ]
-        print('####\n###\n### CMD')
-        print(george_script_lines)
-        print('####\n###\n###')
 
         if scene_bg_color:
             # Change bg color back to previous scene bg colorq


### PR DESCRIPTION
## Changelog Description
Add a new type of export called 'Playblast', which allows :
- Exporting through camera or project view
- Setting custom background directly in scene (by default, all renders have a specific background setted in OpenPype's settings).

Linked ticket : https://github.com/orgs/quadproduction/projects/4/views/3?pane=issue&itemId=40965332

## Additional info
In order to set a specific export type, I had to update the export function from `tv_savesequence ` to `tv_projectsavesequence`. This last function is the only one which get an argument to set a specific export type, and seems to produce the exact same result.

**This branch needs to be merge with the one related to openpype-custom-plugins accessible here : https://github.com/quadproduction/openpype-custom-plugins/pull/20**

## Testing notes:
1. Open tvPaint and a shot
2. Activate the new subset "Playblast" and hit publish
