### PR TITLE
Enhancement/159 enhancement layout reviews publishing tool

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -24,7 +24,7 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
             self._collect_data_for_render_scene(instance)
 
         else:
-            if creator_identifier == "scene.review":
+            if creator_identifier in ["scene.review", "publish.sequence"]:
                 self._collect_data_for_review(instance)
             return
 
@@ -112,3 +112,18 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
         instance.data["layers"] = copy.deepcopy(
             instance.context.data["layersData"]
         )
+
+        transparency_from_creator = instance.data["creator_attributes"].get(
+            "ignore_layers_transparency", None)
+        if transparency_from_creator:
+            instance.data["ignoreLayersTransparency"] = (
+                transparency_from_creator
+                )
+        else:
+            instance.data["ignoreLayersTransparency"] = (
+                self.ignore_render_pass_transparency
+                )
+
+        print('###\n###\n###')
+        print('IGNORE LAYERS TRANSPARENCY')
+        print(instance.data["ignoreLayersTransparency"])

--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -108,18 +108,32 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
             **prepare_template_data({"renderpass": render_pass_name})
         )
 
+    def _get_ignore_transparency_option(self, instance):
+        ignore_transparency = instance.data["creator_attributes"].get(
+            "ignore_layers_transparency", None
+        )
+
+        if not ignore_transparency:
+            keep_transparency = instance.data["creator_attributes"].get(
+                "keep_layers_transparency", None
+            )
+            return not keep_transparency
+
+        else:
+            return ignore_transparency
+
+
     def _collect_data_for_review(self, instance):
         instance.data["layers"] = copy.deepcopy(
             instance.context.data["layersData"]
         )
 
-        transparency_from_creator = instance.data["creator_attributes"].get(
-            "ignore_layers_transparency", None)
-        if transparency_from_creator:
+        ignore_transparency = self._get_ignore_transparency_option(instance)
+        if ignore_transparency:
             instance.data["ignoreLayersTransparency"] = (
-                transparency_from_creator
-                )
+                ignore_transparency
+            )
         else:
             instance.data["ignoreLayersTransparency"] = (
                 self.ignore_render_pass_transparency
-                )
+            )

--- a/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
+++ b/openpype/hosts/tvpaint/plugins/publish/collect_render_instances.py
@@ -123,7 +123,3 @@ class CollectRenderInstances(pyblish.api.InstancePlugin):
             instance.data["ignoreLayersTransparency"] = (
                 self.ignore_render_pass_transparency
                 )
-
-        print('###\n###\n###')
-        print('IGNORE LAYERS TRANSPARENCY')
-        print(instance.data["ignoreLayersTransparency"])

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -115,7 +115,7 @@ class ExtractSequence(pyblish.api.Extractor):
         is_review = instance.data["family"] == "review"
         publish_sequence_with_transparency = (
             instance.data["creator_identifier"] == "publish.sequence" and \
-            not instance.data["creator_attributes"].get('ignore_layers_transparency', False)
+            not ignore_layers_transparency
         )
 
         if is_review or publish_sequence_with_transparency:

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -48,6 +48,12 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         pattern = r"\{([^}]*)\}"
         return re.sub(pattern, replace_missing_key, template)
 
+    def _get_representations_with_sequence_tag(self, representations):
+        return [
+            repr for repr in representations
+            if 'sequence' in repr.get("tags", False)
+        ]
+
     def process(self, context):
         for instance in context:
             # Check if instance is a review by checking its family
@@ -55,11 +61,11 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             families = set(
                 [instance.data["family"]] + instance.data.get("families", [])
             )
-            representation = instance.data.get("representations", [])
+            representations = instance.data.get("representations", [])
 
             # Subset should have a review or a kitsureview tag
+            is_kitsu_review = self._get_representations_with_sequence_tag(representations)
             is_review = "review" in families
-            is_kitsu_review = 'kitsureview' in representation.get("tags", [])
             if not is_review and not is_kitsu_review:
                 continue
 

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -51,7 +51,7 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
     def _get_representations_with_sequence_tag(self, representations):
         return [
             repr for repr in representations
-            if 'sequence' in repr.get("tags", False)
+            if 'sequence' in repr.get("tags", [])
         ]
 
     def process(self, context):

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -55,9 +55,12 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             families = set(
                 [instance.data["family"]] + instance.data.get("families", [])
             )
-            print("\n####\n###")
-            print(families)
-            if "render" not in families:
+            representation = instance.data.get("representations", [])
+
+            # Subset should have a review or a kitsureview tag
+            is_review = "review" in families
+            is_kitsu_review = 'kitsureview' in representation.get("tags", [])
+            if not is_review and not is_kitsu_review:
                 continue
 
             kitsu_task = instance.data.get("kitsu_task")

--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_note.py
@@ -55,7 +55,9 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
             families = set(
                 [instance.data["family"]] + instance.data.get("families", [])
             )
-            if "review" not in families:
+            print("\n####\n###")
+            print(families)
+            if "render" not in families:
                 continue
 
             kitsu_task = instance.data.get("kitsu_task")


### PR DESCRIPTION
## Changelog Description
Add a new subset called "Layout Publish" wich allows artists to publish an image sequence exported from tvPaint and published to Kitsu. OpenPype takes each frame as an output, therefore the scene needs to be constructed in a specific way (1 image type per frame) in order to complete successfully.
The subset also allows to keep layers transparency or not.

Linked ticket : https://github.com/quadproduction/issue_tracker/issues/159

## Additional info
Somes noticeables codes changes have been made in OpenPype's core tvPaint code :
- When collecting render instances, OP will try to get the content of an attribute called `ignore_layers_transparency`. If it doesn't find it, it will also look for another attribute called `keep_layers_transparency` and will convert it to be used as the first option.
- When extracting sequence, OP will trigger an export depending of the `ignore_layers_transparency`. The reason is that one render method doesn't update layers transparency while the other does. 
  **Note :** OP was already using `ignore_layers_transparency` info to reset layers transparency when it was found, but it seemed to be useless as the export method used at this time was always reseting layers transparency, no matter what.
- When extracting sequence, OP was adding a tag `review` if an attribute with the same name was found in families. Now, if it is not the case, OP will add a new tag named `sequence`.

**This branch needs to be merge with his corresponding openpype custom plugin branch here : https://github.com/quadproduction/openpype-custom-plugins/pull/21**

## Testing notes:
1. Open a file in tvPaint (preferably a Layout Posing task file)
2. Use subset Publish Layout and hit publish button
