### PR TITLE
#167: bugfix: tvPaint - when getting current workfile, return a None …

### DIFF
--- a/openpype/hosts/tvpaint/api/pipeline.py
+++ b/openpype/hosts/tvpaint/api/pipeline.py
@@ -164,7 +164,14 @@ class TVPaintHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return session["AVALON_WORKDIR"]
 
     def get_current_workfile(self):
-        return execute_george("tv_GetProjectName")
+        # tvPaint return a '\' character when no scene is currently
+        # opened instead of a None value, which causes interferences
+        # in OpenPype's core code. So we check the returned value and
+        # send None if this character is retrieved.
+        current_workfile = execute_george("tv_GetProjectName")
+        if current_workfile == '\\':
+            current_workfile = None
+        return current_workfile
 
     def workfile_has_unsaved_changes(self):
         return None


### PR DESCRIPTION
…value instead of an antislashewhen current scene is empty / not saved

## Changelog Description
Update `get_current_workfile` function in tvPaint host api to return a None value instead of a `\` character when current scene is empty / not saved. 
This modification solves the issue with the missing extension while trying to import workfile from an empty scene. OpenPype was considering the value returned as a correct workfile name and therefore parsing the data to retrieve an incorrect extension.

Linked ticket : https://github.com/quadproduction/issue_tracker/issues/167

**This branch / commit has been labeled with the wrong ticket number. The corresponding number issue is the 167.**

## Testing notes:
1. Launch an empty scene with tvPaint
2. Try to load a published workfile through `worfiles` dialog window.
