### PR TITLE
#169: bugfixe: add missing 'enabled' attribute to allow deactivation through settings

### DIFF
--- a/openpype/hosts/tvpaint/plugins/create/create_render.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render.py
@@ -1038,6 +1038,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         self.mark_for_review = plugin_settings["mark_for_review"]
         self.active_on_create = plugin_settings["active_on_create"]
         self.default_pass_name = plugin_settings["default_pass_name"]
+        self.enabled = plugin_settings["enabled"]
 
     def get_dynamic_data(self, variant, *args, **kwargs):
         dynamic_data = super().get_dynamic_data(variant, *args, **kwargs)

--- a/openpype/hosts/tvpaint/plugins/create/create_render.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_render.py
@@ -1038,7 +1038,7 @@ class TVPaintSceneRenderCreator(TVPaintAutoCreator):
         self.mark_for_review = plugin_settings["mark_for_review"]
         self.active_on_create = plugin_settings["active_on_create"]
         self.default_pass_name = plugin_settings["default_pass_name"]
-        self.enabled = plugin_settings["enabled"]
+        self.enabled = plugin_settings.get("enabled", True)
 
     def get_dynamic_data(self, variant, *args, **kwargs):
         dynamic_data = super().get_dynamic_data(variant, *args, **kwargs)

--- a/openpype/hosts/tvpaint/plugins/create/create_review.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_review.py
@@ -19,6 +19,7 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
         self.active_on_create = plugin_settings["active_on_create"]
+        self.enabled = plugin_settings["enabled"]
 
     def create(self):
         existing_instance = None

--- a/openpype/hosts/tvpaint/plugins/create/create_review.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_review.py
@@ -19,7 +19,7 @@ class TVPaintReviewCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
         self.active_on_create = plugin_settings["active_on_create"]
-        self.enabled = plugin_settings["enabled"]
+        self.enabled = plugin_settings.get("enabled", True)
 
     def create(self):
         existing_instance = None

--- a/openpype/hosts/tvpaint/plugins/create/create_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_workfile.py
@@ -15,6 +15,7 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
         )
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
+        self.enabled = plugin_settings["enabled"]
 
     def create(self):
         existing_instance = None

--- a/openpype/hosts/tvpaint/plugins/create/create_workfile.py
+++ b/openpype/hosts/tvpaint/plugins/create/create_workfile.py
@@ -15,7 +15,7 @@ class TVPaintWorkfileCreator(TVPaintAutoCreator):
         )
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
-        self.enabled = plugin_settings["enabled"]
+        self.enabled = plugin_settings.get("enabled", True)
 
     def create(self):
         existing_instance = None


### PR DESCRIPTION
## Changelog Description
Add missing `enable` attribute set in internal tvPaint plugins. 

Linked issue : https://github.com/quadproduction/issues/issues/169
**This MR needs to be merge with this one : https://github.com/quadproduction/openpype-custom-plugins/pull/26** 

## Additional info
This is the attribute which seems to be checked by OpenPype to display the plugins in the publish window. Without it, disabling or enabling these in settings have no effect.

## Testing notes:
1. Update state of any tvPaint plugin
2. Launch tvPaint
3. With OpenPype, open the publish menu
