### PR TITLE
Allows user to duplicate rop instance

### DIFF
--- a/openpype/hosts/houdini/api/plugin.py
+++ b/openpype/hosts/houdini/api/plugin.py
@@ -14,7 +14,7 @@ from openpype.pipeline import (
 )
 from openpype.lib import BoolDef
 from .lib import imprint, read, lsattr
-
+from uuid import uuid4
 
 class OpenPypeCreatorError(CreatorError):
     pass
@@ -116,15 +116,27 @@ class HoudiniCreatorBase(object):
         if shared_data.get("houdini_cached_subsets") is None:
             cache = dict()
             cache_legacy = dict()
+            instance_id_list = []
 
             for node in lsattr("id", "pyblish.avalon.instance"):
 
                 creator_identifier_parm = node.parm("creator_identifier")
+                instance_id_parm = node.parm("instance_id")
                 if creator_identifier_parm:
                     # creator instance
                     creator_id = creator_identifier_parm.eval()
+                    instance_id = instance_id_parm.eval()
+                    # Regenerating instance in case of identical values between nodes
+                    if instance_id in instance_id_list or node.path() != node.parm("instance_node").eval():
+                        new_data = {
+                            "instance_node": node.path(),
+                            "instance_id": str(uuid4()),
+                            "subset": node.name()
+                        }
+                        # Refreshing node values
+                        imprint(hou.node(node.path()), new_data, update=True)
                     cache.setdefault(creator_id, []).append(node)
-
+                    instance_id_list.append(instance_id)
                 else:
                     # legacy instance
                     family_parm = node.parm("family")


### PR DESCRIPTION
## Changelog Description
Allows the user to duplicate rop_node and make them publishable by Openpype

## Additional info
Implemented on 3.16.7 OP Version

## Testing notes:
1. `git checkout enhancement/184-enhancement-publish-with-openpype-rop-duplicates-3`
2. Open Houdini in any context
3. Create a OP mantra_rop_node or any rop_node type from `/out/`
4. Copy / Paste / Copy / Paste / etc....
5. Open Publish

## Result

https://github.com/quadproduction/OpenPype/assets/134272390/b8442071-91ee-49ae-b402-6bfd6e56ec89

