### PR TITLE
Fix wrong "subversion" variable for job and batch name

### DIFF
--- a/openpype/modules/deadline/utils.py
+++ b/openpype/modules/deadline/utils.py
@@ -15,7 +15,7 @@ def set_custom_deadline_name(instance, filename, setting):
     subversion = basename.split("_")[-1]
     version = "v" + str(instance.data.get("version")).zfill(3)
 
-    if subversion == version:
+    if re.match(r'^_v[0-9]{3}$', subversion):
         subversion = ""
 
     anatomy_data = context.data.get("anatomyData")

--- a/openpype/modules/deadline/utils.py
+++ b/openpype/modules/deadline/utils.py
@@ -15,7 +15,7 @@ def set_custom_deadline_name(instance, filename, setting):
     subversion = basename.split("_")[-1]
     version = "v" + str(instance.data.get("version")).zfill(3)
 
-    if re.match(r'^_v[0-9]{3}$', subversion):
+    if re.match(r'^v[0-9]{3}$', subversion):
         subversion = ""
 
     anatomy_data = context.data.get("anatomyData")

--- a/openpype/modules/deadline/utils.py
+++ b/openpype/modules/deadline/utils.py
@@ -12,10 +12,12 @@ class SafeDict(dict):
 def set_custom_deadline_name(instance, filename, setting):
     context = instance.context
     basename, ext = os.path.splitext(filename)
-    subversion = basename.split("_")[-1]
     version = "v" + str(instance.data.get("version")).zfill(3)
-
-    if re.match(r'^v[0-9]{3}$', subversion):
+    subversion = basename.split("_")[-1]
+    if re.match(r'^v[0-9]+$', subversion):
+        # If the last part of the filename is the version,
+        # this means there is no subversion (a.k.a comment).
+        # Lets clear the variable
         subversion = ""
 
     anatomy_data = context.data.get("anatomyData")
@@ -49,7 +51,7 @@ def set_custom_deadline_name(instance, filename, setting):
     except Exception as e:
         raise KeyError(
             "OpenPype Studio Settings (Deadline section): Syntax issue(s) "
-            "in \"Job Name\" or \"Batch Name\" for the current project. "
+            "in \"Job Name\" or \"Batch Name\" for the current project.\n"
             "Error: {}".format(e)
         )
 


### PR DESCRIPTION
## Changelog Description
The code for the "subversion" variable was wrong, this should fix it.

## Testing notes:
Send a Maya job on Deadline with subversion and without subversion in the workfile name.