### PR TITLE
Set status project inactive on OP if it is ont active on Ftrack 

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -1953,13 +1953,23 @@ class SyncToAvalonEvent(BaseEvent):
                     self.hier_cust_attrs_changes[key].append(ftrack_id)
                     continue
 
-                if key not in ent_cust_attrs:
+                # This is because "status" is not in custom attributes
+                # but it's a "properties" present in every project
+                # so this will not skip the key
+                if key != "status" and key not in ent_cust_attrs:
                     continue
 
                 value = values["new"]
-                new_value = self.convert_value_by_cust_attr_conf(
-                    value, ent_cust_attrs[key]
-                )
+                # Rename the key because the "status" in ftrack
+                # is called "active" in avalon and is a boolean
+                if key == "status":
+                    key = "active"
+                    new_value = True if value == "active" else False
+                    ent_path = "Project"
+                else:
+                    new_value = self.convert_value_by_cust_attr_conf(
+                        value, ent_cust_attrs[key]
+                    )
 
                 if entType == "show" and key == "applications":
                     # Store apps to project't config
@@ -2672,7 +2682,7 @@ class SyncToAvalonEvent(BaseEvent):
         for ftrack_id, mongo_id in ftrack_mongo_mapping_found.items():
             filter = {"_id": mongo_id}
             change_data = {"$set": {}}
-            change_data["$set"]["data.tasks"] = tasks_per_ftrack_id[ftrack_id]
+            change_data["$set"]["data.active"] = False
             mongo_changes_bulk.append(UpdateOne(filter, change_data))
 
         if mongo_changes_bulk:

--- a/openpype/modules/ftrack/event_handlers_user/action_test.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_test.py
@@ -1,26 +1,55 @@
+from pymongo import UpdateOne
+
 from openpype_modules.ftrack.lib import BaseAction, statics_icon
+from openpype.client import get_projects, get_project
+from openpype.pipeline import AvalonMongoDB
 
 
 class TestAction(BaseAction):
-    """Action for testing purpose or as base for new actions."""
-
-    ignore_me = True
-
+    """Action for testing purpose or as base for new actions.
+    Action currently not used but meant to sync status of projects"""
     identifier = 'test.action'
     label = 'Test action'
     description = 'Test action'
-    priority = 10000
-    role_list = ['Pypeclub']
     icon = statics_icon("ftrack", "action_icons", "TestAction.svg")
+
+    def __init__(self, session):
+        self.dbcon = AvalonMongoDB()
+        super().__init__(session)
 
     def discover(self, session, entities, event):
         return True
 
     def launch(self, session, entities, event):
-        self.log.info(event)
+        projects_to_be_deactived = []
+        disabled_ftrack_projects = session.query(
+            "select id from Project where status is_not active"
+        ).all()
+
+        disabled_ftrack_projects_id = [
+            project['id'] for project in disabled_ftrack_projects
+        ]
+        mongo_projects = get_projects()
+
+        for project in mongo_projects:
+            if project['data'].get('ftrackId') in disabled_ftrack_projects_id:
+                projects_to_be_deactived.append(project)
+                self.log.debug(project['name'])
+
+        # mongo_changes_bulk = []
+        for project in projects_to_be_deactived:
+            filter = {"_id": project["_id"]}
+            change_data = {"$set": {'data.active': False}}
+            self.dbcon.Session["AVALON_PROJECT"] = project['name']
+            self.dbcon.bulk_write([UpdateOne(filter, change_data)])
+            # mongo_changes_bulk.append(UpdateOne(filter, change_data))
+
+        # if mongo_changes_bulk:
+        #     self.dbcon.bulk_write(mongo_changes_bulk)
 
         return True
 
 
 def register(session):
-    TestAction(session).register()
+    # TestAction(session).register()
+    pass


### PR DESCRIPTION
## Changelog Description
Now if WE deactive a project on Ftrack, thé corresponding project on OP should be deactivated too.

## Testing notes:
1. set a project "active" or "hidden" on Ftrack
2. See if the status if the project in OP is the same 
