### PR TITLE
Auto generate first workfile based on build template with workfile

### DIFF
--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -645,9 +645,9 @@ def on_new():
     """Set project resolution and fps when create a new file"""
     log.info("Running callback on new..")
     with lib.suspended_refresh():
-        utils.executeDeferred(_autobuild_first_workfile)
         lib.set_context_settings()
 
+    utils.executeDeferred(_autobuild_first_workfile)
     utils.executeDeferred(_update_render_layer_observers)
     _remove_workfile_lock()
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -39,7 +39,10 @@ from openpype.pipeline import (
     AVALON_CONTAINER_ID,
 )
 from openpype.pipeline.load import any_outdated_containers
-from openpype.pipeline.workfile import workfile_template_builder
+from openpype.pipeline.workfile import (
+    is_last_workfile_exists,
+    should_build_first_workfile
+)
 from openpype.pipeline.workfile.lock_workfile import (
     create_workfile_lock,
     remove_workfile_lock,
@@ -596,10 +599,7 @@ def _update_render_layer_observers():
 
 
 def _autobuild_first_workfile():
-    if (
-        workfile_template_builder.should_build_first_workfile()
-        and not workfile_template_builder.is_workfile_exists()
-    ):
+    if not is_last_workfile_exists() and should_build_first_workfile():
         build_workfile_template()
 
 

--- a/openpype/hosts/maya/api/pipeline.py
+++ b/openpype/hosts/maya/api/pipeline.py
@@ -596,7 +596,10 @@ def _update_render_layer_observers():
 
 
 def _autobuild_first_workfile():
-    if workfile_template_builder.should_build_first_workfile():
+    if (
+        workfile_template_builder.should_build_first_workfile()
+        and not workfile_template_builder.is_workfile_exists()
+    ):
         build_workfile_template()
 
 

--- a/openpype/pipeline/workfile/__init__.py
+++ b/openpype/pipeline/workfile/__init__.py
@@ -15,6 +15,12 @@ from .path_resolving import (
 
 from .build_workfile import BuildWorkfile
 
+from .workfile_template_builder import (
+    get_last_workfile_path,
+    is_last_workfile_exists,
+    should_build_first_workfile
+)
+
 
 __all__ = (
     "get_workfile_template_key_from_context",
@@ -31,4 +37,8 @@ __all__ = (
     "create_workdir_extra_folders",
 
     "BuildWorkfile",
+
+    "get_last_workfile_path",
+    "is_last_workfile_exists",
+    "should_build_first_workfile"
 )

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -62,9 +62,6 @@ from openpype.pipeline.context_tools import (
 )
 
 
-log = logging.getLogger(__name__)
-
-
 class TemplateNotFound(Exception):
     """Exception raised when template does not exist."""
     pass
@@ -606,9 +603,9 @@ class AbstractTemplateBuilder(object):
             template_path (str): Fullpath for current task and
                 host's template file.
         """
-        last_workfile_path = os.environ.get("AVALON_LAST_WORKFILE")
-        workfile_exists = is_workfile_exists()
-        if workfile_exists:
+        last_workfile_path = get_last_workfile_path()
+        self.log.info("__ last_workfile_path: {}".format(last_workfile_path))
+        if is_last_workfile_exists():
             # ignore in case workfile existence
             self.log.info("Workfile already exists, skipping creation.")
             return False
@@ -2022,10 +2019,14 @@ def should_build_first_workfile(
     return True
 
 
-def is_workfile_exists():
-    last_workfile_path = os.environ.get("AVALON_LAST_WORKFILE")
-    log.info("__ last_workfile_path: {}".format(last_workfile_path))
+def get_last_workfile_path():
+    return os.environ.get("AVALON_LAST_WORKFILE")
+
+
+def is_last_workfile_exists():
+    last_workfile_path = get_last_workfile_path()
 
     if last_workfile_path and os.path.exists(last_workfile_path):
         return True
+
     return False

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -16,7 +16,6 @@ import re
 import collections
 import copy
 from abc import ABCMeta, abstractmethod
-import logging
 
 import six
 

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -16,6 +16,7 @@ import re
 import collections
 import copy
 from abc import ABCMeta, abstractmethod
+import logging
 
 import six
 
@@ -59,6 +60,9 @@ from openpype.pipeline.context_tools import (
     get_current_task_name,
     get_current_host_name
 )
+
+
+log = logging.getLogger(__name__)
 
 
 class TemplateNotFound(Exception):
@@ -603,8 +607,8 @@ class AbstractTemplateBuilder(object):
                 host's template file.
         """
         last_workfile_path = os.environ.get("AVALON_LAST_WORKFILE")
-        self.log.info("__ last_workfile_path: {}".format(last_workfile_path))
-        if os.path.exists(last_workfile_path):
+        workfile_exists = is_workfile_exists()
+        if workfile_exists:
             # ignore in case workfile existence
             self.log.info("Workfile already exists, skipping creation.")
             return False
@@ -2016,3 +2020,12 @@ def should_build_first_workfile(
         return False
 
     return True
+
+
+def is_workfile_exists():
+    last_workfile_path = os.environ.get("AVALON_LAST_WORKFILE")
+    log.info("__ last_workfile_path: {}".format(last_workfile_path))
+
+    if last_workfile_path and os.path.exists(last_workfile_path):
+        return True
+    return False

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_templated_workfile_build.json
@@ -40,6 +40,12 @@
                         "label": "Create first version",
                         "type": "boolean",
                         "default": true
+                    },
+                    {
+                        "key": "autobuild_first_version",
+                        "label": "Autobuild first version",
+                        "type": "boolean",
+                        "default": true
                     }
                 ]
             }


### PR DESCRIPTION
## Changelog Description
Add a new setting in the "Templated Workfile Build Settings" part of maya's project settings. If actvie, call the temlpate build workfile if no workfile exists for the current task.

## Testing notes:
1. Go in the maya project settings and check "Autobuild first version" for a task without a workfile
2. Open maya in the right task
3. The template should be built automatically
