### PR TITLE
Fix  permission issue

### DIFF
--- a/openpype/lib/file_transaction.py
+++ b/openpype/lib/file_transaction.py
@@ -207,7 +207,15 @@ class FileTransaction(object):
             self.log.debug('User : {0}'.format(os.getlogin()))
             self.log.debug('Python Version : {0}'.format(sys.version))
             os.umask(0)
-            os.makedirs(dirname)
+            os.makedirs(dirname, mode=0o777)
+            import datetime
+            from pathlib import Path
+            debug_filepath = Path(path).joinpath("debug.txt")
+            with open(debug_filepath, "a") as f:
+                f.write("User : {}\nDate : {%Y-%m-%d %H:%M:%S (Timezone: %Z)}\nPython Version : {}\n".format(
+                    os.getlogin(),
+                    datetime.datetime.now(),
+                    sys.version))
         except OSError as e:
             if e.errno == errno.EEXIST:
                 pass

--- a/openpype/lib/file_transaction.py
+++ b/openpype/lib/file_transaction.py
@@ -203,6 +203,10 @@ class FileTransaction(object):
     def _create_folder_for_file(self, path):
         dirname = os.path.dirname(path)
         try:
+            # TEMP DEBUG
+            self.log.debug('User : {0}'.format(os.getlogin()))
+            self.log.debug('Python Version : {0}'.format(sys.version))
+            os.umask(0)
             os.makedirs(dirname)
         except OSError as e:
             if e.errno == errno.EEXIST:


### PR DESCRIPTION
Afin de régler le problème de permission un log du user ainsi que la version de python a été mis en place pour nous aider à comprendre ce qu'il se passe dans Deadline et OP au moment de la création des dossiers.

De plus, il a été décidé de forcer le umask a 0.