### PR TITLE
[Maya] Include handles for OP 3.16

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -2309,6 +2309,8 @@ def get_frame_range(include_animation_range=False):
             animation_start -= int(handle_start)
             animation_end += int(handle_end)
 
+        frame_range["frameStart"] = animation_start
+        frame_range["frameEnd"] = animation_end
         frame_range["animationStart"] = animation_start
         frame_range["animationEnd"] = animation_end
 


### PR DESCRIPTION
## Changelog Description
Include the handle frame data in Maya 'Openpype > Set Frame Range'  for OP 3.16

## Testing notes:
1. Take a random Shot item in ftrack and set a custom handle
2. Open Openpype, go to your Shot context, Open Maya 
3.  Click on 'Openpype > Set Frame Range' 
4. Timeline should be set correctly based on ftrack data

PS : cf. https://github.com/quadproduction/OpenPype/pull/588