### PR TITLE
Fix the priority for the publish job in deadline

### DIFF
--- a/openpype/modules/deadline/plugins/common/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/plugins/common/publish/submit_publish_job.py
@@ -237,7 +237,7 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
                 environment["OPENPYPE_MONGO"] = mongo_url
 
         # Using instance priority, OR if not set, project priority
-        priority = instance.data.get("priority", self.deadline_priority)
+        priority = instance.data['publish_attributes']['MayaSubmitDeadline'].get('priority', self.deadline_priority)  # noqa
         if priority is None:
             # This shouldn't happen, but let's be extra careful
             priority = 50


### PR DESCRIPTION
## Changelog Description
This fix the feature that set the same priority for the render job and the publish job.
This fix was needed because in the 3.16 version of OP, the priority is no longer at the root of the instance dict, but in the publish attributes that store the render instance data (attributes settable in the create menu like pools, machine limit, frames per task, ...)