### PR TITLE
use first frame as thumbnail for review (quadproduction/issues#240)

### DIFF
--- a/openpype/hosts/houdini/plugins/publish/extract_opengl.py
+++ b/openpype/hosts/houdini/plugins/publish/extract_opengl.py
@@ -49,3 +49,7 @@ class ExtractOpenGL(publish.Extractor):
         if "representations" not in instance.data:
             instance.data["representations"] = []
         instance.data["representations"].append(representation)
+
+        # Use the first image as a thumbnail if it's not already set.
+        if not instance.data.get("thumbnailSource") and output:
+            instance.data["thumbnailSource"] = os.path.join(staging_dir, output[0])


### PR DESCRIPTION
## Changelog Description
Add thumbnail to Houdini review.

## Additional info
If the thumbnail is not already set, use first frame for the thumbnail.

## Testing notes:

1. Checkout to this branch and tun Openpype.
2. Open Houdini and publish a review. (example: Project=TEST_OP2_PUB_23_7, Asset: chair, Task: model)