### PR TITLE
add gizmo and plugin paths to NUKE_PATH for the farm (quadproduction/…

### DIFF
--- a/openpype/modules/deadline/plugins/nuke/publish/submit_nuke_deadline.py
+++ b/openpype/modules/deadline/plugins/nuke/publish/submit_nuke_deadline.py
@@ -367,13 +367,13 @@ class NukeSubmitDeadline(pyblish.api.InstancePlugin,
         if self.env_allowed_keys:
             keys += self.env_allowed_keys
 
-        # add all gizmo and plugin paths to the NUKE_PATH for the render farm
-        nuke_path = os.environ.get("NUKE_PATH") or ""
-        new_nuke_paths = [path for path in nuke_path.split(os.pathsep) if path]
-        for path in nuke.pluginPath():
-            if path not in new_nuke_paths:
-                new_nuke_paths.append(path)
-        os.environ["NUKE_PATH"] = os.pathsep.join(new_nuke_paths)
+        # add all gizmos and plugin paths to the NUKE_PATH for the render farm
+        nuke_path = os.environ.get("NUKE_PATH", "")
+        nuke_paths = [path for path in nuke_path.split(os.pathsep) if path]
+        for nuke_plugin_path in nuke.pluginPath():
+            if nuke_plugin_path not in nuke_paths:
+                nuke_paths.append(nuke_plugin_path)
+        os.environ["NUKE_PATH"] = os.pathsep.join(nuke_paths)
 
         environment = dict({key: os.environ[key] for key in keys
                             if key in os.environ}, **legacy_io.Session)


### PR DESCRIPTION
…issues#168)

## Changelog Description
Fix missing nuke plugins and gizmos on the render farm

## Additional info
The plugins and gizmo paths are now added to the NUKE_PATH so that the render farm find them. 

## Testing notes:
1. Checkout to this branch. 
2. Run opfix and open nuke on a project. (example: project=TEST_OP2_PUB_23_7, shot=001_0010, task=compo)
3. Create a scene containing a gizmo (example: push_pixel) or use the existing scene.
4. Create Render subset if there is not one in the scene.
5. Publish on the farm and check if the rendering job finish without any error.
