### PR TITLE
Add a more specific message for duplicated items in Ftrack

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_sync_to_avalon.py
@@ -879,7 +879,6 @@ class SyncToAvalonEvent(BaseEvent):
             username = user_entity["username"] or username
         return username
 
-
     def process_removed(self):
         """
             Handles removed entities (not removed tasks - handle separately).
@@ -2536,7 +2535,8 @@ class SyncToAvalonEvent(BaseEvent):
             "type": "label",
             "value": (
                 "<p><i>NOTE: It is not allowed to use the same name"
-                " for multiple entities in the same project</i></p>"
+                " for multiple entities in the same project. Please"
+                " delete or rename your newly created item.</i></p>"
             )
         })
 


### PR DESCRIPTION
## Changelog Description
Add precision in duplicate warning pop up telling the user to delete or rename the duplicated item.

## Testing notes:
1. on Ftrack, create an asset already existing in a different folder
2. after the synchro, a pop up should appear with the modified message
