### PR TITLE
supports the settings of additional plugin info and job info

### DIFF
--- a/openpype/modules/deadline/maya/publish/submit_maya_deadline.py
+++ b/openpype/modules/deadline/maya/publish/submit_maya_deadline.py
@@ -136,6 +136,9 @@ class MayaSubmitDeadline(abstract_submit_deadline.AbstractSubmitDeadline,
         cls.strict_error_checking = settings.get("strict_error_checking",
                                                  cls.strict_error_checking)
 
+        cls.jobInfo = settings.get("jobInfo", cls.jobInfo)
+        cls.pluginInfo = settings.get("pluginInfo", cls.pluginInfo)
+
     def get_job_info(self):
         job_info = DeadlineJobInfo(Plugin="MayaBatch")
 


### PR DESCRIPTION
## Changelog Description
supports the settings of additional plugin info and job info

## Testing notes:
1. Set your desired parameter in project_settings/deadline/publish/MayaSubmitDeadline/pluginInfo
2. Publish a render scene inside Maya
3. Checkout if the parameter is in the Submission Params of the Job properties on Deadline Monitor. 
