### PR TITLE
Fix locked anatomy attributes for project creation

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -3,7 +3,6 @@ import copy
 
 from openpype.client import get_project, create_project
 from openpype.settings import ProjectSettings, SaveWarningExc
-from openpype.settings.entities import BoolEntity
 from openpype_modules.ftrack.lib import (
     BaseAction,
     statics_icon,

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -407,7 +407,7 @@ class PrepareProjectLocal(BaseAction):
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
         # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        dummy_bool_false_obj = BoolEntity("boolean", None)
+        dummy_bool_false_obj = BoolEntity({}, None)
         dummy_bool_false_obj.set(False)
         project_anatomy_settings.non_gui_children["bypass_protect_anatomy_attributes"] = dummy_bool_false_obj
 

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -407,7 +407,7 @@ class PrepareProjectLocal(BaseAction):
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
         # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = False
+        project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -407,9 +407,7 @@ class PrepareProjectLocal(BaseAction):
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
         # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        dummy_bool_false_obj = BoolEntity({}, None)
-        dummy_bool_false_obj.set(False)
-        project_anatomy_settings.non_gui_children["bypass_protect_anatomy_attributes"] = dummy_bool_false_obj
+        project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = False
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -406,6 +406,8 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
+        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
+        project_anatomy_settings["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -406,6 +406,8 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
+        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
+        project_anatomy_settings.non_gui_children["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]
@@ -414,9 +416,6 @@ class PrepareProjectLocal(BaseAction):
                 custom_attribute_values[key] = value
             else:
                 attributes_entity[key] = value
-
-        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        project_anatomy_settings["attributes"]["bypass_protect_anatomy_attributes"] = True
 
         try:
             project_settings.save()

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -3,7 +3,7 @@ import copy
 
 from openpype.client import get_project, create_project
 from openpype.settings import ProjectSettings, SaveWarningExc
-
+from openpype.settings.entities import BoolEntity
 from openpype_modules.ftrack.lib import (
     BaseAction,
     statics_icon,
@@ -407,7 +407,9 @@ class PrepareProjectLocal(BaseAction):
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
         # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        project_anatomy_settings.non_gui_children["bypass_protect_anatomy_attributes"] = True
+        dummy_bool_false_obj = BoolEntity("boolean", None)
+        dummy_bool_false_obj.set(False)
+        project_anatomy_settings.non_gui_children["bypass_protect_anatomy_attributes"] = dummy_bool_false_obj
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -406,8 +406,6 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
-        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        project_anatomy_settings["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]
@@ -416,6 +414,9 @@ class PrepareProjectLocal(BaseAction):
                 custom_attribute_values[key] = value
             else:
                 attributes_entity[key] = value
+
+        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
+        project_anatomy_settings["attributes"]["bypass_protect_anatomy_attributes"] = True
 
         try:
             project_settings.save()

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -2,6 +2,7 @@ import os
 import json
 import collections
 import platform
+import inspect
 
 import click
 
@@ -292,9 +293,18 @@ class FtrackModule(
             # If no values or same as before, then just skip the update process
             return
 
+        # Get all the files called to trigger this function
+        callers_filename = []
+        stack = inspect.stack()
+        for frame in stack:
+            caller_filename = frame.filename
+            caller_filename = os.path.basename(caller_filename)
+            caller_filename = os.path.splitext(caller_filename)[0]
+            callers_filename.append(caller_filename)
+
         system_settings = get_system_settings()
         protect_attrs = system_settings["general"].get("project", {}).get("protect_anatomy_attributes", False)
-        if protect_attrs and old_attr_values.keys() == new_attr_values.keys():
+        if protect_attrs and "action_prepare_project" not in callers_filename:
             self.log.warning("Anatomy attributes are protected/locked. "
                              "The only way to modify them is through the project settings on Ftrack.")
             return

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -2,7 +2,6 @@ import os
 import json
 import collections
 import platform
-import inspect
 
 import click
 
@@ -293,18 +292,15 @@ class FtrackModule(
             # If no values or same as before, then just skip the update process
             return
 
-        # Get all the files called to trigger this function
-        callers_filename = []
-        stack = inspect.stack()
-        for frame in stack:
-            caller_filename = frame.filename
-            caller_filename = os.path.basename(caller_filename)
-            caller_filename = os.path.splitext(caller_filename)[0]
-            callers_filename.append(caller_filename)
-
         system_settings = get_system_settings()
         protect_attrs = system_settings["general"].get("project", {}).get("protect_anatomy_attributes", False)
-        if protect_attrs and "action_prepare_project" not in callers_filename:
+
+        # If we just create the project on the server (prepare project) we want to send attributes to Ftrack
+        bypass_protect_anatomy_attributes = new_value_metadata.get("bypass_protect_anatomy_attributes", False)
+        if bypass_protect_anatomy_attributes:
+            protect_attrs = False
+
+        if protect_attrs:
             self.log.warning("Anatomy attributes are protected/locked. "
                              "The only way to modify them is through the project settings on Ftrack.")
             return

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -296,7 +296,7 @@ class FtrackModule(
         protect_attrs = system_settings["general"].get("project", {}).get("protect_anatomy_attributes", False)
 
         # If we just create the project on the server (prepare project) we want to send attributes to Ftrack
-        bypass_protect_anatomy_attributes = new_attr_values.pop("bypass_protect_anatomy_attributes", False)
+        bypass_protect_anatomy_attributes = new_value_metadata.get("bypass_protect_anatomy_attributes", False)
         if bypass_protect_anatomy_attributes:
             protect_attrs = False
 

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -298,6 +298,7 @@ class FtrackModule(
         # If we just create the project on the server (prepare project) we want to send attributes to Ftrack
         bypass_protect_anatomy_attributes = new_value_metadata.get("bypass_protect_anatomy_attributes", False)
         if bypass_protect_anatomy_attributes:
+            # Disable the protection
             protect_attrs = False
 
         if protect_attrs:

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -294,7 +294,7 @@ class FtrackModule(
 
         system_settings = get_system_settings()
         protect_attrs = system_settings["general"].get("project", {}).get("protect_anatomy_attributes", False)
-        if protect_attrs:
+        if protect_attrs and old_attr_values.keys() == new_attr_values.keys():
             self.log.warning("Anatomy attributes are protected/locked. "
                              "The only way to modify them is through the project settings on Ftrack.")
             return

--- a/openpype/modules/ftrack/ftrack_module.py
+++ b/openpype/modules/ftrack/ftrack_module.py
@@ -296,7 +296,7 @@ class FtrackModule(
         protect_attrs = system_settings["general"].get("project", {}).get("protect_anatomy_attributes", False)
 
         # If we just create the project on the server (prepare project) we want to send attributes to Ftrack
-        bypass_protect_anatomy_attributes = new_value_metadata.get("bypass_protect_anatomy_attributes", False)
+        bypass_protect_anatomy_attributes = new_attr_values.pop("bypass_protect_anatomy_attributes", False)
         if bypass_protect_anatomy_attributes:
             protect_attrs = False
 

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -289,6 +289,8 @@ def save_project_anatomy(project_name, anatomy_data):
 
     new_data_with_metadata = copy.deepcopy(new_data)
     clear_metadata_from_settings(new_data)
+    # Removing the needed bypass flag from the data dict (leaving it in new_data_with_metadata)
+    new_data.non_gui_children.pop("bypass_protect_anatomy_attributes", None)
 
     changes = calculate_changes(old_data, new_data)
     modules_manager = ModulesManager()

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -271,6 +271,7 @@ def save_project_anatomy(project_name, anatomy_data):
     Raises:
         SaveWarningExc: If any module raises the exception.
     """
+    bypass_protect_attrs = anatomy_data.pop("bypass_protect_anatomy_attributes", None)
     # Notify Pype modules
     from openpype.modules import ModulesManager, ISettingsChangeListener
 
@@ -288,9 +289,9 @@ def save_project_anatomy(project_name, anatomy_data):
         new_data = apply_overrides(default_values, copy.deepcopy(anatomy_data))
 
     new_data_with_metadata = copy.deepcopy(new_data)
+    if bypass_protect_attrs is not None:
+        new_data_with_metadata["bypass_protect_anatomy_attributes"] = bypass_protect_attrs
     clear_metadata_from_settings(new_data)
-    # Removing the needed bypass flag from the data dict (leaving it in new_data_with_metadata)
-    new_data.non_gui_children.pop("bypass_protect_anatomy_attributes", None)
 
     changes = calculate_changes(old_data, new_data)
     modules_manager = ModulesManager()

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -289,8 +289,6 @@ def save_project_anatomy(project_name, anatomy_data):
 
     new_data_with_metadata = copy.deepcopy(new_data)
     clear_metadata_from_settings(new_data)
-    # Removing the needed bypass flag from the data dict
-    new_data.pop("bypass_protect_anatomy_attributes", None)
 
     changes = calculate_changes(old_data, new_data)
     modules_manager = ModulesManager()

--- a/openpype/settings/lib.py
+++ b/openpype/settings/lib.py
@@ -289,6 +289,8 @@ def save_project_anatomy(project_name, anatomy_data):
 
     new_data_with_metadata = copy.deepcopy(new_data)
     clear_metadata_from_settings(new_data)
+    # Removing the needed bypass flag from the data dict
+    new_data.pop("bypass_protect_anatomy_attributes", None)
 
     changes = calculate_changes(old_data, new_data)
     modules_manager = ModulesManager()


### PR DESCRIPTION
## Changelog Description
When creating a new project on Ftrack, the OP attributes were not set with the Prepare Project action due to the protection of the anatomy settings. I added a check of the attributes: if there's new attribute to set, the protection is disabled.

## Testing notes:
1. create a new project on Ftrack
2. do the Prepare Project action on the new project
3. check if the attributes are correctly set
