### PR TITLE
Add predefined pool for Nuke publish and prerender jobs

### DIFF
--- a/openpype/modules/deadline/common/publish/collect_pools.py
+++ b/openpype/modules/deadline/common/publish/collect_pools.py
@@ -15,6 +15,7 @@ class CollectDeadlinePools(pyblish.api.InstancePlugin,
     label = "Collect Deadline Pools"
     families = ["rendering",
                 "render.farm",
+                "render.frames_farm",
                 "renderFarm",
                 "renderlayer",
                 "maxrender"]

--- a/openpype/modules/deadline/common/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/common/publish/submit_publish_job.py
@@ -157,6 +157,17 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
     # poor man exclusion
     skip_integration_repre_list = []
 
+    @classmethod
+    def apply_settings(cls, project_settings, system_settings):
+        # deadline.publish.ProcessSubmittedJobOnFarm
+        settings = project_settings["deadline"]["publish"]["ProcessSubmittedJobOnFarm"]  # noqa
+
+        cls.deadline_department = settings.get("deadline_department", "")
+        cls.deadline_pool = settings.get("deadline_pool", "")
+        cls.deadline_group = settings.get("deadline_group", "")
+        cls.deadline_chunk_size = settings.get("deadline_chunk_size", 1)
+        cls.deadline_priority = settings.get("deadline_priority", None)
+
     def _submit_deadline_post_job(self, instance, job, instances):
         """Submit publish job to Deadline.
 


### PR DESCRIPTION
## Changelog Description
This PR will add deadline pools to the publish and baking jobs when publishing "`use existing frames - far`m" in Nuke.

## Testing notes:
You can use this scene for testing purpose: Project: **LA_FIEVRE_P2_23_52,** Shot: **990_0020**, Task: **compo**
1. First, you should publish the two render jobs, select "`Farm Rendering`" as target and suspend publish jobs. This way you will have the frames needed for the next step. You can un check workfile publish. 
2. Once you have frames ready, you do a publish, but this time select "`use existing frame - farm`" as target. Leave review checked.
3. You should see the publish and baking jobs on deadline and they should have `fix` as pool.
