### PR TITLE
Add include/exclude handles to ValidateFrameRange process

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -53,6 +53,21 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
             )
             return
 
+        # Check the include handle settings of the actual project
+        include_handles_settings = context.data["project_settings"]["maya"]["include_handles"]
+        current_task = context.data["anatomyData"]["task"]["name"]
+        include_task_handles = False
+        # Define if we had to include/exclude the handles
+        for item in include_handles_settings["per_task_type"]:
+            if current_task in item["task_type"]:
+                include_task_handles = item["include_handles"]
+        # if we exclude, initialize handles values to origin(frame start, frame end)
+        if not include_task_handles:
+            context.data["frameStartHandle"] = int(context.data.get("frameStart"))
+            context.data["frameEndHandle"] = int(context.data.get("frameEnd"))
+            context.data["handleStart"] = 0
+            context.data["handleEnd"] = 0
+
         frame_start_handle = int(context.data.get("frameStartHandle"))
         frame_end_handle = int(context.data.get("frameEndHandle"))
         handle_start = int(context.data.get("handleStart"))

--- a/openpype/hosts/maya/plugins/publish/validate_frame_range.py
+++ b/openpype/hosts/maya/plugins/publish/validate_frame_range.py
@@ -61,6 +61,8 @@ class ValidateFrameRange(pyblish.api.InstancePlugin,
         for item in include_handles_settings["per_task_type"]:
             if current_task in item["task_type"]:
                 include_task_handles = item["include_handles"]
+                break
+
         # if we exclude, initialize handles values to origin(frame start, frame end)
         if not include_task_handles:
             context.data["frameStartHandle"] = int(context.data.get("frameStart"))

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -222,8 +222,8 @@
             "label": "Include/Exclude Handles in default playback & render range",
             "children": [
                 {
-                            "type": "label",
-                            "label": "WARNING: Do not add the same task twice."
+                    "type": "label",
+                    "label": "WARNING: Do not add the same task in multiple items of the include/exclude list below."
                 },
                 {
                     "key": "include_handles_default",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -223,7 +223,8 @@
             "children": [
                 {
                             "type": "label",
-                            "label": "WARNING: Do not add the same task twice."},
+                            "label": "WARNING: Do not add the same task twice."
+                },
                 {
                     "key": "include_handles_default",
                     "label": "Include handles by default",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_maya.json
@@ -222,6 +222,9 @@
             "label": "Include/Exclude Handles in default playback & render range",
             "children": [
                 {
+                            "type": "label",
+                            "label": "WARNING: Do not add the same task twice."},
+                {
                     "key": "include_handles_default",
                     "label": "Include handles by default",
                     "type": "boolean"


### PR DESCRIPTION
## Changelog Description
Add include/exclude handles settings during the ValidateFrameRange() process managed by Maya

## Testing notes:
1. `git checkout bugfix/209-bug-validate-frame-range-without-handles`
2. Check the task does not include handles in the settings, for example 'light' task
![image](https://github.com/quadproduction/OpenPype/assets/134272390/5eed12d0-bf7c-476a-9414-f416a30c9227)
3. Open 'light' task in TEST_OP2_PUB_23_7 > 003 > 003_0010
4. As you see the light task contains handles in Ftrack
5. Select `Openpype > Publish` in the top bar menu
![image](https://github.com/quadproduction/OpenPype/assets/134272390/cf33df76-6f9e-4638-aada-72ef5c1703be)
6. Publish has been sent with success in Deadline and publish job (659d814a1489900628ea7d6c
659d814a1489900628ea7d6d) will generate the sequence without handles.
