### PR TITLE
Reactivating a Ftrack user with Active deadline jobs 

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
@@ -1,12 +1,12 @@
 import ftrack_api
 from openpype_modules.ftrack.lib import BaseEvent
-from openpype.modules.deadline.deadline_module import DeadlineModule
+from openpype.modules import ModulesManager
 
 
 class KeepUserActiveForDeadline(BaseEvent):
 
     def launch(self, session, event):
-        '''Ensure the user stays active while having an ongoing job in the Deadline.'''
+        """Ensure the user stays active while having an ongoing job in the Deadline."""
         if not event.get('data'):
             return
 
@@ -66,13 +66,19 @@ class KeepUserActiveForDeadline(BaseEvent):
     def get_user_active_deadline_jobs(self, user):
         """Get all active deadline jobs of the user
         """
-        deadline_url = "http://deadline.prs.vfx.int:8081"
+        manager = ModulesManager()
+        deadline_module = manager.modules_by_name["deadline"]
+        deadline_url = deadline_module.deadline_urls["default"]
+
+        if not deadline_url:
+            self.log.info("Deadline URL not found, skipping.")
+            return
 
         requested_arguments = {
             "States":"Active"
         }
 
-        jobs = DeadlineModule.get_deadline_data(
+        jobs = deadline_module.get_deadline_data(
             deadline_url,
             "jobs",
             log=None,
@@ -87,5 +93,5 @@ class KeepUserActiveForDeadline(BaseEvent):
         return user_jobs
 
 def register(session):
-    '''Register plugin. Called when used as an plugin.'''
+    """Register plugin. Called when used as an plugin."""
     KeepUserActiveForDeadline(session).register()

--- a/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
@@ -6,7 +6,7 @@ from openpype.modules import ModulesManager
 class KeepUserActiveForDeadline(BaseEvent):
 
     def launch(self, session, event):
-        """Ensure the user stays active while having an ongoing job in the Deadline."""
+        """Ensure the user stays active while having ongoing job(s) in the Deadline."""
         if not event.get('data'):
             return
 
@@ -20,7 +20,7 @@ class KeepUserActiveForDeadline(BaseEvent):
             return
         if entity_info.get('action', "") != "update":
             return
-        if not "isactive" in entity_info.get('changes', {}):
+        if "isactive" not in entity_info.get('changes', {}):
             return
         if entity_info['changes']['isactive'].get('new') != False:
             return
@@ -47,7 +47,7 @@ class KeepUserActiveForDeadline(BaseEvent):
             {
                 "type": "label",
                 "value": "The following jobs from this user are currently active "
-                            "on deadline:\n{}".format("\n".join(job_ids))
+                         "on deadline:\n{}".format("\n".join(job_ids))
             },
             {
                 "type": "label",
@@ -75,7 +75,7 @@ class KeepUserActiveForDeadline(BaseEvent):
             return
 
         requested_arguments = {
-            "States":"Active"
+            "States": "Active"
         }
 
         jobs = deadline_module.get_deadline_data(
@@ -87,10 +87,11 @@ class KeepUserActiveForDeadline(BaseEvent):
 
         user_jobs = []
         for job in jobs:
-            if job['Props']['Env'].get('FTRACK_API_USER')==user:
+            if job['Props']['Env'].get('FTRACK_API_USER') == user:
                 user_jobs.append(job['_id'])
 
         return user_jobs
+
 
 def register(session):
     """Register plugin. Called when used as an plugin."""

--- a/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_keep_user_active_for_deadline.py
@@ -1,0 +1,82 @@
+import ftrack_api
+from openpype_modules.ftrack.lib import BaseEvent
+from openpype.modules.deadline.deadline_module import DeadlineModule
+
+
+class KeepUserActiveForDeadline(BaseEvent):
+
+    def launch(self, session, event):
+        '''Ensure the user stays active while having an ongoing job in the Deadline.'''
+        if not event.get('data'):
+            return
+
+        entities_info = event['data'].get('entities')
+        if not entities_info:
+            return
+
+        entity_info = entities_info[0]
+        # check if a user has been deactivated
+        if entity_info.get('entity_type') != "User":
+            return
+        if entity_info.get('action', "") != "update":
+            return
+        if not "isactive" in entity_info.get('changes', {}):
+            return
+        if entity_info['changes']['isactive'].get('new') != False:
+            return
+
+        user = session.get('User', entity_info.get('entityId'))
+        if not user:
+            return
+
+        job_ids = self.get_user_active_deadline_jobs(user)
+        if job_ids:
+            # activate the account
+            user['is_active'] = True
+            session.commit()
+            # Return the issue message form
+            return {
+                "type": "form",
+                "items": [
+                    {
+                        "type": "label",
+                        "value": "#Warning: The user has been re-activated!"
+                    },
+                    {
+                        "type": "label",
+                        "value": "The following jobs from this user are currently active "
+                                    "on deadline:\n{}".format("\n".join(job_ids))
+                    },
+                    {
+                        "type": "label",
+                        "value": "Please try later when all the jobs are done."
+                    }
+                ],
+                "title": "Create Project Structure",
+                "submit_button_label": "I will do the changes"
+            }
+
+    def get_user_active_deadline_jobs(self, user):
+        """Get all active deadline jobs of the user
+        """
+        deadline_url = "http://deadline.prs.vfx.int:8081"
+
+        requested_arguments = {
+            # "IdOnly": True,
+            "States":"Active"
+        }
+
+        jobs = DeadlineModule.get_deadline_data(
+            deadline_url,
+            "jobs",
+            log=None,
+            **requested_arguments
+        )
+
+        user_jobs = [job['_id'] for job in jobs if job['Props']['User']==user]
+
+        return user_jobs
+
+def register(session):
+    '''Register plugin. Called when used as an plugin.'''
+    KeepUserActiveForDeadline(session).register()


### PR DESCRIPTION
## Changelog Description
Implemented user reactivation to prevent publish job crashes when a Ftrack user with “**Active**” deadline jobs is deactivated.

## Additional info
Note that Active covers both **Queued** and **Rendering** Jobs. 

## Testing notes:
1. Checkout to this branch. 
2. Run a Ftrack Sync Server locally. Do not run it in parallel of the production sync server. 
3. Try to deactivate a user on Ftrack who has active jobs on deadline. 
