### PR TITLE
#284: enhancement: synchronize project state at sync execution (before listening to events)

### DIFF
--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -310,7 +310,7 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
         UpdateOne: Update instance for the project
     """
     project_name = project["name"]
-    project_dict = get_project(project_name, inactive=True)
+    project_dict = get_project(project_name)
     if not project_dict:
         project_dict = create_project(project_name, project_name)
 

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -490,11 +490,13 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
     bulk_writes.append(write_project_to_op(project, dbcon))
 
     if project["project_status_name"] == "Closed":
-        update_project_state_in_db(
-            dbcon,
-            project_dict,
-            active=KitsuStateToBool[project["project_status_name"]]
-        )
+        active_state = KitsuStateToBool[project["project_status_name"]]
+        if project_dict['data']['active'] != active_state:
+            update_project_state_in_db(
+                dbcon,
+                project_dict,
+                active=active_state
+            )
         return
 
     # Try to find project document

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -490,12 +490,13 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
     bulk_writes.append(write_project_to_op(project, dbcon))
 
     if project["project_status_name"] == "Closed":
-        active_state = KitsuStateToBool[project["project_status_name"]]
-        if project_dict['data']['active'] != active_state:
+        kitsu_active_state = KitsuStateToBool[project["project_status_name"]]
+        op_active_state = project_dict.get('data', {}).get('active', None)
+        if op_active_state != kitsu_active_state:
             update_project_state_in_db(
                 dbcon,
                 project_dict,
-                active=active_state
+                active=kitsu_active_state
             )
         return
 

--- a/openpype/modules/kitsu/utils/update_op_with_zou.py
+++ b/openpype/modules/kitsu/utils/update_op_with_zou.py
@@ -332,7 +332,7 @@ def write_project_to_op(project: dict, dbcon: AvalonMongoDB) -> UpdateOne:
             "code": project_code,
             "fps": float(project["fps"]),
             "zou_id": project["id"],
-            "active": project["project_status_name"] != "Closed",
+            "active": KitsuStateToBool[project["project_status_name"]]
         }
     )
 
@@ -489,9 +489,6 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
     # Sync project. Create if doesn't exist
     project_name = project["name"]
     project_dict = get_project(project_name)
-    if not project_dict:
-        log.info("Project created: {}".format(project_name))
-    bulk_writes.append(write_project_to_op(project, dbcon))
 
     if project["project_status_name"] == "Closed":
         kitsu_active_state = KitsuStateToBool[project["project_status_name"]]
@@ -503,6 +500,10 @@ def sync_project_from_kitsu(dbcon: AvalonMongoDB, project: dict):
                 active=kitsu_active_state
             )
         return
+
+    if not project_dict:
+        log.info("Project created: {}".format(project_name))
+    bulk_writes.append(write_project_to_op(project, dbcon))
 
     # Try to find project document
     if not project_dict:


### PR DESCRIPTION
## Changelog Description
Update Kitsu sync to also set the active test from all projects at sync launch.

## Testing notes:
1. Manipulate Kitsu productions
2. Launch sync (better to use a local mongodb by setting environment variable `OPENPYPE_MONGO`)
