### PR TITLE
Auto comment on version with the source workfile in it

### DIFF
--- a/openpype/modules/ftrack/__init__.py
+++ b/openpype/modules/ftrack/__init__.py
@@ -5,13 +5,13 @@ from .ftrack_module import (
     resolve_ftrack_url,
 )
 
-from .utils import get_asset_version_by_task_id
+from .utils import get_asset_versions_by_task_id
 
 __all__ = (
     "FtrackModule",
     "FTRACK_MODULE_DIR",
 
-    "get_asset_version_by_task_id",
+    "get_asset_versions_by_task_id",
 
     "resolve_ftrack_url",
 )

--- a/openpype/modules/ftrack/__init__.py
+++ b/openpype/modules/ftrack/__init__.py
@@ -5,9 +5,13 @@ from .ftrack_module import (
     resolve_ftrack_url,
 )
 
+from .utils import get_asset_version_by_task_id
+
 __all__ = (
     "FtrackModule",
     "FTRACK_MODULE_DIR",
+
+    "get_asset_version_by_task_id",
 
     "resolve_ftrack_url",
 )

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_description.py
@@ -35,7 +35,7 @@ class IntegrateFtrackDescription(pyblish.api.InstancePlugin):
         asset_versions_key = "ftrackIntegratedAssetVersionsData"
         asset_versions_data_by_id = instance.data.get(asset_versions_key)
         if not asset_versions_data_by_id:
-            self.log.info("There are any integrated AssetVersions")
+            self.log.info("There are no integrated AssetVersions")
             return
 
         comment = instance.data["comment"]

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
@@ -9,10 +9,10 @@ import sys
 import six
 from pathlib import Path
 
-from ftrack_api.exception import NoResultFoundError
 import pyblish.api
 
 from openpype.settings import get_current_project_settings
+from openpype.modules.ftrack import get_asset_version_by_task_id
 
 
 class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
@@ -36,7 +36,7 @@ class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
             asset_versions_key
         ) or instance.data.get(asset_versions_key_backwards_compatible)
         if not asset_version_data:
-            asset_version_data = self.get_asset_version_by_task_id(
+            asset_version_data = get_asset_version_by_task_id(
                 session,
                 task['id'],
                 name
@@ -71,16 +71,3 @@ class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
             session.rollback()
             session._configure_locations()
             six.reraise(tp, value, tb)
-
-    def get_asset_version_by_task_id(self, session, task_id, name):
-        try:
-            asset_version = session.query(
-                f"AssetVersion where task_id is {task_id}"
-                " and is_latest_version is True"
-                f" and asset has (name is {name})"
-            ).one()
-        except NoResultFoundError:
-            self.log.debug("No AssetVersion found")
-            return None
-
-        return asset_version

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
@@ -24,33 +24,56 @@ class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
-        # Check if there are any integrated AssetVersion entities
-        asset_versions_key = "ftrackIntegratedAssetVersionsData"
-        asset_versions_data_by_id = instance.data.get(asset_versions_key)
-        if not asset_versions_data_by_id:
-            self.log.info("There are any integrated AssetVersions")
-            return
-
-        context = instance.context
-        filename = context.data["currentFile"]
-        is_full_path = get_current_project_settings()["ftrack"]["publish"]["IntegrateFtrackSourceWorkfile"]["full_path"]
-        if is_full_path:
-            filename = str(Path(filename).resolve())
-        else:
-            filename = Path(filename).name
-
+        task = instance.data.get("ftrackTask")
+        name = instance.data.get("name")
+        asset_version = None
+        version = 0
         session = instance.context.data["ftrackSession"]
-        for asset_version_data in asset_versions_data_by_id.values():
-            asset_version = asset_version_data["asset_version"]
-            asset_version["custom_attributes"]["fix_fromworkfile"] = filename
 
-            try:
-                session.commit()
-                self.log.debug("Source workfile: {} added to AssetVersion \"{}\"".format(
-                    filename, str(asset_version)
-                ))
-            except Exception:
-                tp, value, tb = sys.exc_info()
-                session.rollback()
-                session._configure_locations()
-                six.reraise(tp, value, tb)
+        asset_versions = session.query(f"AssetVersion where task_id is \"{task['id']}\"").all()
+        for asset in asset_versions:
+            if asset['asset']['name'] == name:
+                if asset['version'] > version:
+                    version = asset['version']
+                    asset_version = asset
+
+        if asset_version:
+            self.log.debug(f"ASSET VERSION: {asset_version['asset']['name']}, VERSION: {asset_version['version']}")
+
+        # Check if there are any integrated AssetVersion entities
+        # asset_versions_key = "ftrackIntegratedAssetVersionsData"
+        # asset_versions_data_by_id = instance.data.get(asset_versions_key)
+        # if not asset_versions_data_by_id:
+        #     # for asset in instance.data["ftrackEntity"].get("assets"):
+        #     #     self.log.debug(f"ASSET: {asset['name']}")
+        #     asset_versions_key = "ftrackIntegratedAssetVersions"
+        #     asset_versions_data_by_id = instance.data.get(asset_versions_key)
+        #     if not asset_versions_data_by_id:
+        #         self.log.info("There are any integrated AssetVersions")
+        #         return
+        #     else:
+        #         self.log.debug("Using old key: {}".format(asset_versions_data_by_id))
+
+        # context = instance.context
+        # filename = context.data["currentFile"]
+        # is_full_path = get_current_project_settings()["ftrack"]["publish"]["IntegrateFtrackSourceWorkfile"]["full_path"]
+        # if is_full_path:
+        #     filename = str(Path(filename).resolve())
+        # else:
+        #     filename = Path(filename).name
+
+        # session = instance.context.data["ftrackSession"]
+        # for asset_version_data in asset_versions_data_by_id.values():
+        #     asset_version = asset_version_data["asset_version"]
+        #     asset_version["custom_attributes"]["fix_fromworkfile"] = filename
+
+        #     try:
+        #         session.commit()
+        #         self.log.debug("Source workfile: {} added to AssetVersion \"{}\"".format(
+        #             filename, str(asset_version)
+        #         ))
+        #     except Exception:
+        #         tp, value, tb = sys.exc_info()
+        #         session.rollback()
+        #         session._configure_locations()
+        #         six.reraise(tp, value, tb)

--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_source_workfile.py
@@ -12,14 +12,14 @@ from pathlib import Path
 import pyblish.api
 
 from openpype.settings import get_current_project_settings
-from openpype.modules.ftrack import get_asset_version_by_task_id
+from openpype.modules.ftrack import get_asset_versions_by_task_id
 
 
 class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
     """Add source workfile filename to AssetVersions in Ftrack."""
 
     # Must be after integrate asset new
-    order = pyblish.api.IntegratorOrder + 0.4999
+    order = pyblish.api.IntegratorOrder + 0.5000
     label = "Integrate Ftrack source workfile"
     families = ["ftrack"]
     optional = True
@@ -31,43 +31,44 @@ class IntegrateFtrackSourceWorkfile(pyblish.api.InstancePlugin):
 
         # Check if there are any integrated AssetVersion entities
         asset_versions_key = "ftrackIntegratedAssetVersionsData"
-        asset_versions_key_backwards_compatible = "ftrackIntegratedAssetVersionsData"  # noqa
-        asset_version_data = instance.data.get(
-            asset_versions_key
-        ) or instance.data.get(asset_versions_key_backwards_compatible)
-        if not asset_version_data:
-            asset_version_data = get_asset_version_by_task_id(
-                session,
-                task['id'],
-                name
-            )
-        else:
-            for asset_version in asset_version_data.values():
-                asset_version_data = asset_version["asset_version"]
+        asset_versions_data_by_id = instance.data.get(asset_versions_key, [])
 
-        if not asset_version_data:
+        if not asset_versions_data_by_id:
+            # Backwards compatibility
+            asset_versions_alt_key = "ftrackIntegratedAssetVersions"
+            asset_versions_data_by_id = instance.data.get(asset_versions_alt_key, [])
+
+        if not asset_versions_data_by_id:
+            # Last way to try retrieving the asset versions
+            asset_versions_data_by_id = get_asset_versions_by_task_id(
+                session, task['id'], name)
+
+        if not asset_versions_data_by_id:
             self.log.debug("No AssetVersion found")
             return
 
-        context = instance.context
-        filename = context.data["currentFile"]
+        # Get the workfile name or fullpath
+        workfile = instance.context.data["currentFile"]
         is_full_path = get_current_project_settings()["ftrack"]["publish"]["IntegrateFtrackSourceWorkfile"]["full_path"]  # noqa
         if is_full_path:
-            filename = str(Path(filename).resolve())
+            workfile = str(Path(workfile).resolve())
         else:
-            filename = Path(filename).name
+            workfile = Path(workfile).name
 
-        asset_version_data["custom_attributes"]["fix_fromworkfile"] = filename
+        # Add it to the asset version
+        for asset_version_data in asset_versions_data_by_id.values():
+            asset_version = asset_version_data["asset_version"]
+            asset_version["custom_attributes"]["fix_fromworkfile"] = workfile
 
-        try:
-            session.commit()
-            self.log.debug(
-                "Source workfile: {} added to AssetVersion \"{}\"".format(
-                    filename, str(asset_version_data)
+            try:
+                session.commit()
+                self.log.debug(
+                    "Source workfile: {} added to AssetVersion \"{}\"".format(
+                        workfile, str(asset_version_data)
+                    )
                 )
-            )
-        except Exception:
-            tp, value, tb = sys.exc_info()
-            session.rollback()
-            session._configure_locations()
-            six.reraise(tp, value, tb)
+            except Exception: # noqa
+                tp, value, tb = sys.exc_info()
+                session.rollback()
+                session._configure_locations()
+                six.reraise(tp, value, tb)

--- a/openpype/modules/ftrack/utils.py
+++ b/openpype/modules/ftrack/utils.py
@@ -1,0 +1,14 @@
+from ftrack_api.exception import NoResultFoundError
+
+
+def get_asset_version_by_task_id(session, task_id, name):
+    try:
+        asset_version = session.query(
+            f"AssetVersion where task_id is {task_id}"
+            " and is_latest_version is True"
+            f" and asset has (name is {name})"
+        ).one()
+    except NoResultFoundError:
+        return None
+
+    return asset_version

--- a/openpype/modules/ftrack/utils.py
+++ b/openpype/modules/ftrack/utils.py
@@ -1,14 +1,14 @@
 from ftrack_api.exception import NoResultFoundError
 
 
-def get_asset_version_by_task_id(session, task_id, name):
+def get_asset_versions_by_task_id(session, task_id, name):
     try:
-        asset_version = session.query(
+        asset_versions = session.query(
             f"AssetVersion where task_id is {task_id}"
             " and is_latest_version is True"
             f" and asset has (name is {name})"
-        ).one()
+        ).all()
     except NoResultFoundError:
-        return None
+        return []
 
-    return asset_version
+    return asset_versions


### PR DESCRIPTION
## Changelog Description
This PR is here to fix this feature. Sometimes the AssetVersion data are not in the instance, so we have to do a query to ftrack in order to get the latest AssetVersion for the current asset.

