### PR TITLE
Add status on instance creator

### DIFF
--- a/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
+++ b/openpype/hosts/maya/plugins/create/create_arnold_scene_source.py
@@ -4,8 +4,11 @@ from openpype.hosts.maya.api import (
 )
 from openpype.lib import (
     NumberDef,
-    BoolDef
+    BoolDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateArnoldSceneSource(plugin.MayaCreator):
@@ -36,6 +39,10 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
 
         defs = lib.collect_animation_defs()
 
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
             BoolDef("expandProcedural",
                     label="Expand Procedural",
@@ -51,6 +58,10 @@ class CreateArnoldSceneSource(plugin.MayaCreator):
                       label="Motion Blur Length",
                       decimals=3,
                       default=self.motionBlurLength),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
 
             # Masks
             BoolDef("maskOptions",

--- a/openpype/hosts/maya/plugins/create/create_camera.py
+++ b/openpype/hosts/maya/plugins/create/create_camera.py
@@ -2,7 +2,12 @@ from openpype.hosts.maya.api import (
     lib,
     plugin
 )
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateCamera(plugin.MayaCreator):
@@ -17,7 +22,15 @@ class CreateCamera(plugin.MayaCreator):
 
         defs = lib.collect_animation_defs()
 
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
             BoolDef("bakeToWorldSpace",
                     label="Bake to World-Space",
                     tooltip="Bake to World-Space",
@@ -34,3 +47,15 @@ class CreateCameraRig(plugin.MayaCreator):
     label = "Camera Rig"
     family = "camerarig"
     icon = "video-camera"
+
+    def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
+        return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ]

--- a/openpype/hosts/maya/plugins/create/create_layout.py
+++ b/openpype/hosts/maya/plugins/create/create_layout.py
@@ -1,5 +1,10 @@
 from openpype.hosts.maya.api import plugin
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateLayout(plugin.MayaCreator):
@@ -11,8 +16,15 @@ class CreateLayout(plugin.MayaCreator):
     icon = "cubes"
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
             BoolDef("groupLoadedAssets",
                     label="Group Loaded Assets",
                     tooltip="Enable this when you want to publish group of "

--- a/openpype/hosts/maya/plugins/create/create_look.py
+++ b/openpype/hosts/maya/plugins/create/create_look.py
@@ -4,8 +4,11 @@ from openpype.hosts.maya.api import (
 )
 from openpype.lib import (
     BoolDef,
-    TextDef
+    TextDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateLook(plugin.MayaCreator):
@@ -20,6 +23,9 @@ class CreateLook(plugin.MayaCreator):
     rs_tex = False
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
             # TODO: This value should actually get set on create!
@@ -37,7 +43,11 @@ class CreateLook(plugin.MayaCreator):
                     label="Convert textures to .rstex",
                     tooltip="Whether to generate Redshift .rstex files for "
                             "your textures",
-                    default=self.rs_tex)
+                    default=self.rs_tex),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ]
 
     def get_pre_create_attr_defs(self):

--- a/openpype/hosts/maya/plugins/create/create_maya_usd.py
+++ b/openpype/hosts/maya/plugins/create/create_maya_usd.py
@@ -4,6 +4,8 @@ from openpype.lib import (
     EnumDef,
     TextDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 from maya import cmds
 
@@ -45,6 +47,10 @@ class CreateMayaUsd(plugin.MayaCreator):
             self.cache["jobContextItems"] = job_context_items
 
         defs = lib.collect_animation_defs()
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
             EnumDef("defaultUSDFormat",
                     label="File format",
@@ -97,6 +103,10 @@ class CreateMayaUsd(plugin.MayaCreator):
                         "specific\ntask, a target renderer for example."
                     ),
                     multiselection=True),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_mayascene.py
+++ b/openpype/hosts/maya/plugins/create/create_mayascene.py
@@ -1,4 +1,7 @@
 from openpype.hosts.maya.api import plugin
+from openpype.lib import EnumDef
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateMayaScene(plugin.MayaCreator):
@@ -9,3 +12,15 @@ class CreateMayaScene(plugin.MayaCreator):
     label = "Maya Scene"
     family = "mayaScene"
     icon = "file-archive-o"
+
+    def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
+        return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ]

--- a/openpype/hosts/maya/plugins/create/create_model.py
+++ b/openpype/hosts/maya/plugins/create/create_model.py
@@ -1,8 +1,11 @@
 from openpype.hosts.maya.api import plugin
 from openpype.lib import (
     BoolDef,
-    TextDef
+    TextDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateModel(plugin.MayaCreator):
@@ -18,6 +21,9 @@ class CreateModel(plugin.MayaCreator):
     write_face_sets = False
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
             BoolDef("writeColorSets",
@@ -33,6 +39,10 @@ class CreateModel(plugin.MayaCreator):
                     tooltip="Whether to include parent hierarchy of nodes in "
                             "the publish instance",
                     default=False),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
             TextDef("attr",
                     label="Custom Attributes",
                     default="",

--- a/openpype/hosts/maya/plugins/create/create_multiverse_look.py
+++ b/openpype/hosts/maya/plugins/create/create_multiverse_look.py
@@ -3,6 +3,8 @@ from openpype.lib import (
     BoolDef,
     EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateMultiverseLook(plugin.MayaCreator):
@@ -14,6 +16,9 @@ class CreateMultiverseLook(plugin.MayaCreator):
     icon = "cubes"
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
             EnumDef("fileFormat",
@@ -24,4 +29,8 @@ class CreateMultiverseLook(plugin.MayaCreator):
             BoolDef("publishMipMap",
                     label="Publish MipMap",
                     default=True),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ]

--- a/openpype/hosts/maya/plugins/create/create_multiverse_usd.py
+++ b/openpype/hosts/maya/plugins/create/create_multiverse_usd.py
@@ -5,6 +5,8 @@ from openpype.lib import (
     TextDef,
     EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateMultiverseUsd(plugin.MayaCreator):
@@ -22,6 +24,10 @@ class CreateMultiverseUsd(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs(fps=True)
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",
@@ -56,6 +62,10 @@ class CreateMultiverseUsd(plugin.MayaCreator):
                     label="Node Types to Ignore",
                     tooltip="Comma-separated list of node types to be ignored",
                     default=''),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
             BoolDef("writeMeshes",
                     label="Write Meshes",
                     default=True),

--- a/openpype/hosts/maya/plugins/create/create_multiverse_usd_comp.py
+++ b/openpype/hosts/maya/plugins/create/create_multiverse_usd_comp.py
@@ -4,6 +4,8 @@ from openpype.lib import (
     NumberDef,
     EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateMultiverseUsdComp(plugin.MayaCreator):
@@ -17,6 +19,10 @@ class CreateMultiverseUsdComp(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs(fps=True)
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",
@@ -43,6 +49,10 @@ class CreateMultiverseUsdComp(plugin.MayaCreator):
             NumberDef("timeSamplesSpan",
                       label="Time Samples Span",
                       default=0.0),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_multiverse_usd_over.py
+++ b/openpype/hosts/maya/plugins/create/create_multiverse_usd_over.py
@@ -4,6 +4,8 @@ from openpype.lib import (
     NumberDef,
     EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateMultiverseUsdOver(plugin.MayaCreator):
@@ -16,6 +18,10 @@ class CreateMultiverseUsdOver(plugin.MayaCreator):
 
     def get_instance_attr_defs(self):
         defs = lib.collect_animation_defs(fps=True)
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         defs.extend([
             EnumDef("fileFormat",
                     label="File format",
@@ -54,6 +60,10 @@ class CreateMultiverseUsdOver(plugin.MayaCreator):
             NumberDef("timeSamplesSpan",
                       label="Time Samples Span",
                       default=0.0),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_pointcache.py
+++ b/openpype/hosts/maya/plugins/create/create_pointcache.py
@@ -6,8 +6,11 @@ from openpype.hosts.maya.api import (
 )
 from openpype.lib import (
     BoolDef,
-    TextDef
+    TextDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreatePointCache(plugin.MayaCreator):
@@ -24,6 +27,9 @@ class CreatePointCache(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs()
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs.extend([
             BoolDef("writeColorSets",
@@ -64,7 +70,11 @@ class CreatePointCache(plugin.MayaCreator):
             TextDef("attrPrefix",
                     label="Custom Attributes Prefix",
                     default="",
-                    placeholder="prefix1, prefix2")
+                    placeholder="prefix1, prefix2"),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         # TODO: Implement these on a Deadline plug-in instead?

--- a/openpype/hosts/maya/plugins/create/create_proxy_abc.py
+++ b/openpype/hosts/maya/plugins/create/create_proxy_abc.py
@@ -4,8 +4,11 @@ from openpype.hosts.maya.api import (
 )
 from openpype.lib import (
     BoolDef,
-    TextDef
+    TextDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateProxyAlembic(plugin.MayaCreator):
@@ -21,6 +24,9 @@ class CreateProxyAlembic(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs()
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs.extend([
             BoolDef("writeColorSets",
@@ -44,7 +50,11 @@ class CreateProxyAlembic(plugin.MayaCreator):
                     placeholder="attr1, attr2"),
             TextDef("attrPrefix",
                     label="Custom Attributes Prefix",
-                    placeholder="prefix1, prefix2")
+                    placeholder="prefix1, prefix2"),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_redshift_proxy.py
+++ b/openpype/hosts/maya/plugins/create/create_redshift_proxy.py
@@ -2,7 +2,12 @@
 """Creator of Redshift proxy subset types."""
 
 from openpype.hosts.maya.api import plugin, lib
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateRedshiftProxy(plugin.MayaCreator):
@@ -14,12 +19,21 @@ class CreateRedshiftProxy(plugin.MayaCreator):
     icon = "gears"
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs = [
             BoolDef("animation",
                     label="Export animation",
-                    default=False)
+                    default=False),
         ]
 
         defs.extend(lib.collect_animation_defs())
+        defs.extend([
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ])
         return defs

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -114,6 +114,10 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
                       default=2,
                       minimum=1,
                       decimals=0),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=["N/A", "In Progress", "Pending", "Review"],
+                    default="N/A"),
 
             # Additional settings
             BoolDef("convertToScanline",

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Create ``Render`` instance in Maya."""
 
-
 from openpype.settings import (
     get_system_settings
 )
@@ -15,7 +14,10 @@ from openpype.lib import (
     NumberDef,
     EnumDef
 )
-from openpype.pipeline.context_tools import _get_modules_manager
+from openpype.pipeline.context_tools import (
+    _get_modules_manager,
+    get_current_project_name
+)
 from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
@@ -69,7 +71,9 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
         limit_groups = self._get_limit_groups(
             deadline_enabled, deadline_url
         )
-        statuses = get_ftrack_statuses()
+
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
 
         return [
             BoolDef("review",

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -74,6 +74,7 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
 
         project_name = get_current_project_name()
         statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
             BoolDef("review",

--- a/openpype/hosts/maya/plugins/create/create_render.py
+++ b/openpype/hosts/maya/plugins/create/create_render.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Create ``Render`` instance in Maya."""
 
+
 from openpype.settings import (
     get_system_settings
 )
@@ -15,6 +16,7 @@ from openpype.lib import (
     EnumDef
 )
 from openpype.pipeline.context_tools import _get_modules_manager
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateRenderlayer(plugin.RenderlayerCreator):
@@ -61,13 +63,13 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
         modules_system_settings = get_system_settings()["modules"]
         deadline_enabled = modules_system_settings["deadline"]["enabled"]
         deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default")
-
         default_machine_limit = self._get_default_machine_limit(
             deadline_enabled
         )
         limit_groups = self._get_limit_groups(
             deadline_enabled, deadline_url
         )
+        statuses = get_ftrack_statuses()
 
         return [
             BoolDef("review",
@@ -116,8 +118,8 @@ class CreateRenderlayer(plugin.RenderlayerCreator):
                       decimals=0),
             EnumDef("ftrackStatus",
                     label="Ftrack Status",
-                    items=["N/A", "In Progress", "Pending", "Review"],
-                    default="N/A"),
+                    items=statuses,
+                    default="In progress"),
 
             # Additional settings
             BoolDef("convertToScanline",

--- a/openpype/hosts/maya/plugins/create/create_review.py
+++ b/openpype/hosts/maya/plugins/create/create_review.py
@@ -13,6 +13,8 @@ from openpype.lib import (
 )
 from openpype.pipeline import CreatedInstance
 from openpype.client import get_asset_by_name
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 TRANSPARENCIES = [
     "preset",
@@ -89,6 +91,9 @@ class CreateReview(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs()
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         # Option for using Maya or asset frame range in settings.
         if not self.useMayaTimeline:
@@ -137,6 +142,10 @@ class CreateReview(plugin.MayaCreator):
             EnumDef("displayLights",
                     label="Display Lights",
                     items=lib.DISPLAY_LIGHTS_ENUM),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_rig.py
@@ -1,6 +1,9 @@
 from maya import cmds
 
 from openpype.hosts.maya.api import plugin
+from openpype.lib import EnumDef
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateRig(plugin.MayaCreator):
@@ -23,3 +26,15 @@ class CreateRig(plugin.MayaCreator):
         controls = cmds.sets(name=subset_name + "_controls_SET", empty=True)
         pointcache = cmds.sets(name=subset_name + "_out_SET", empty=True)
         cmds.sets([controls, pointcache], forceElement=instance_node)
+
+    def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
+        return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ]

--- a/openpype/hosts/maya/plugins/create/create_setdress.py
+++ b/openpype/hosts/maya/plugins/create/create_setdress.py
@@ -1,5 +1,10 @@
 from openpype.hosts.maya.api import plugin
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateSetDress(plugin.MayaCreator):
@@ -12,8 +17,16 @@ class CreateSetDress(plugin.MayaCreator):
     default_variants = ["Main", "Anim"]
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
         return [
             BoolDef("exactSetMembersOnly",
                     label="Exact Set Members Only",
-                    default=True)
+                    default=True),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ]

--- a/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_skeletalmesh.py
@@ -3,8 +3,11 @@
 from openpype.hosts.maya.api import plugin, lib
 from openpype.lib import (
     BoolDef,
-    TextDef
+    TextDef,
+    EnumDef
 )
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 from maya import cmds  # noqa
 
@@ -68,6 +71,9 @@ class CreateUnrealSkeletalMesh(plugin.MayaCreator):
     def get_instance_attr_defs(self):
 
         defs = lib.collect_animation_defs()
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs.extend([
             BoolDef("renderableOnly",
@@ -96,7 +102,11 @@ class CreateUnrealSkeletalMesh(plugin.MayaCreator):
                     placeholder="attr1, attr2"),
             TextDef("attrPrefix",
                     label="Custom Attributes Prefix",
-                    placeholder="prefix1, prefix2")
+                    placeholder="prefix1, prefix2"),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
+++ b/openpype/hosts/maya/plugins/create/create_unreal_staticmesh.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Creator for Unreal Static Meshes."""
 from openpype.hosts.maya.api import plugin, lib
+from openpype.lib import EnumDef
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
+
+
 from maya import cmds  # noqa
 
 
@@ -88,3 +93,15 @@ class CreateUnrealStaticMesh(plugin.MayaCreator):
             if node_name.startswith(prefix):
                 return True
         return False
+
+    def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
+        return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ]

--- a/openpype/hosts/maya/plugins/create/create_vrayproxy.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayproxy.py
@@ -2,7 +2,12 @@ from openpype.hosts.maya.api import (
     plugin,
     lib
 )
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateVrayProxy(plugin.MayaCreator):
@@ -17,6 +22,9 @@ class CreateVrayProxy(plugin.MayaCreator):
     alembic = True
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs = [
             BoolDef("animation",
@@ -45,6 +53,10 @@ class CreateVrayProxy(plugin.MayaCreator):
                     tooltip="Publish a .abc (Alembic) file for "
                             "this VRayProxy",
                     default=self.alembic),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_vrayscene.py
+++ b/openpype/hosts/maya/plugins/create/create_vrayscene.py
@@ -6,7 +6,12 @@ from openpype.hosts.maya.api import (
     plugin
 )
 from openpype.pipeline import CreatorError
-from openpype.lib import BoolDef
+from openpype.lib import (
+    BoolDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateVRayScene(plugin.RenderlayerCreator):
@@ -41,6 +46,9 @@ class CreateVRayScene(plugin.RenderlayerCreator):
 
     def get_instance_attr_defs(self):
         """Create instance settings."""
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         return [
             BoolDef("vraySceneMultipleFiles",
@@ -48,5 +56,9 @@ class CreateVRayScene(plugin.RenderlayerCreator):
                     default=False),
             BoolDef("exportOnFarm",
                     label="Export on farm",
-                    default=False)
+                    default=False),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
         ]

--- a/openpype/hosts/maya/plugins/create/create_yeti_cache.py
+++ b/openpype/hosts/maya/plugins/create/create_yeti_cache.py
@@ -2,7 +2,12 @@ from openpype.hosts.maya.api import (
     lib,
     plugin
 )
-from openpype.lib import NumberDef
+from openpype.lib import (
+    NumberDef,
+    EnumDef
+)
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateYetiCache(plugin.MayaCreator):
@@ -14,6 +19,9 @@ class CreateYetiCache(plugin.MayaCreator):
     icon = "pagelines"
 
     def get_instance_attr_defs(self):
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
 
         defs = [
             NumberDef("preroll",
@@ -29,11 +37,15 @@ class CreateYetiCache(plugin.MayaCreator):
         defs = [attr_def for attr_def in defs if attr_def.key not in remove]
 
         # Add samples after frame range
-        defs.append(
+        defs.extend([
             NumberDef("samples",
                       label="Samples",
                       default=3,
-                      decimals=0)
-        )
+                      decimals=0),
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ])
 
         return defs

--- a/openpype/hosts/maya/plugins/create/create_yeti_rig.py
+++ b/openpype/hosts/maya/plugins/create/create_yeti_rig.py
@@ -4,6 +4,9 @@ from openpype.hosts.maya.api import (
     lib,
     plugin
 )
+from openpype.lib import EnumDef
+from openpype.pipeline.context_tools import get_current_project_name
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class CreateYetiRig(plugin.MayaCreator):
@@ -25,3 +28,16 @@ class CreateYetiRig(plugin.MayaCreator):
             self.log.info("Creating Rig instance set up ...")
             input_meshes = cmds.sets(name="input_SET", empty=True)
             cmds.sets(input_meshes, forceElement=instance_node)
+
+    def get_instance_attr_defs(self):
+        """Create instance settings."""
+        project_name = get_current_project_name()
+        statuses = get_ftrack_statuses(project_name)
+        statuses = sorted([status['name'] for status in statuses])
+
+        return [
+            EnumDef("ftrackStatus",
+                    label="Ftrack Status",
+                    items=statuses,
+                    default="In progress"),
+        ]

--- a/openpype/modules/ftrack/lib/__init__.py
+++ b/openpype/modules/ftrack/lib/__init__.py
@@ -17,6 +17,7 @@ from .custom_attributes import (
     get_openpype_attr,
     query_custom_attributes
 )
+from .utils import get_ftrack_statuses
 
 from . import avalon_sync
 from . import credentials
@@ -41,6 +42,8 @@ __all__ = (
     "tool_definitions_from_app_manager",
     "get_openpype_attr",
     "query_custom_attributes",
+
+    "get_ftrack_statuses",
 
     "avalon_sync",
 

--- a/openpype/modules/ftrack/lib/utils.py
+++ b/openpype/modules/ftrack/lib/utils.py
@@ -1,9 +1,20 @@
 import ftrack_api
 
 
-def get_ftrack_statuses():
+def get_ftrack_statuses(project_name):
     session = ftrack_api.Session(auto_connect_event_hub=False)
-    statuses = session.query("Status").all()
-    statuses = [status["name"] for status in statuses]
+    statuses_name = []
 
-    return sorted(statuses)
+    project_entity = session.query((
+        "select project_schema from Project where full_name is \"{}\""
+    ).format(project_name)).one()
+    project_schema = project_entity["project_schema"]
+    task_type_ids = {
+        task_type["id"]
+        for task_type in session.query("select id from Type").all()
+    }
+    statuses = project_schema.get_statuses("Task", task_type_ids)
+    for status in statuses:
+        statuses_name.append(status["name"])
+
+    return sorted(statuses_name)

--- a/openpype/modules/ftrack/lib/utils.py
+++ b/openpype/modules/ftrack/lib/utils.py
@@ -17,4 +17,4 @@ def get_ftrack_statuses(project_name):
     for status in statuses:
         statuses_name.append(status["name"])
 
-    return sorted(statuses_name)
+    return statuses

--- a/openpype/modules/ftrack/lib/utils.py
+++ b/openpype/modules/ftrack/lib/utils.py
@@ -1,0 +1,9 @@
+import ftrack_api
+
+
+def get_ftrack_statuses():
+    session = ftrack_api.Session(auto_connect_event_hub=False)
+    statuses = session.query("Status").all()
+    statuses = [status["name"] for status in statuses]
+
+    return sorted(statuses)

--- a/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
@@ -6,6 +6,7 @@ import pyblish.api
 
 from openpype.settings import get_current_project_settings
 from openpype.modules.ftrack import get_asset_version_by_task_id
+from openpype.modules.ftrack.lib import get_ftrack_statuses
 
 
 class IntegrateInstanceStatusToFtrack(pyblish.api.InstancePlugin):
@@ -16,8 +17,6 @@ class IntegrateInstanceStatusToFtrack(pyblish.api.InstancePlugin):
     active = True
 
     def process(self, instance):
-        self.log.debug(f"SATUTS_TO_SET: {instance.data['creator_attributes'].get('ftrack_status')}")
-
         task = instance.data.get("ftrackTask")
         name = instance.data.get("name")
         session = instance.context.data["ftrackSession"]
@@ -43,14 +42,26 @@ class IntegrateInstanceStatusToFtrack(pyblish.api.InstancePlugin):
             return
 
         instance_status = instance.data['creator_attributes'].get(
-            'ftrack_status'
+            'ftrackStatus'
         )
-        asset_version_data["status"] = instance_status
+        if not instance_status:
+            instance_status = "N/A"
+        project_name = instance.context.data.get("projectName")
+        statuses = get_ftrack_statuses(project_name)
+        status = [status for status in statuses if status['name'] == instance_status]  # noqa
+
+        if not status:
+            self.log.debug(
+                "Status \"{}\" not found in Ftrack".format(instance_status)
+            )
+            return
+
+        asset_version_data["status"] = status[0]
 
         try:
-            # session.commit()
+            session.commit()
             self.log.debug(
-                "Status set to {} for AssetVersion \"{}\" ".format(
+                "Status set to \"{}\" for AssetVersion \"{}\" ".format(
                     instance_status, str(asset_version_data)
                 )
             )

--- a/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
@@ -1,11 +1,61 @@
+import sys
+import six
+from pathlib import Path
+
 import pyblish.api
+
+from openpype.settings import get_current_project_settings
+from openpype.modules.ftrack import get_asset_version_by_task_id
 
 
 class IntegrateInstanceStatusToFtrack(pyblish.api.InstancePlugin):
 
-    order = pyblish.api.IntegratorOrder + 0.49
+    order = pyblish.api.IntegratorOrder + 0.4999
     label = "Integrate Instance Status To Ftrack"
+    families = ["ftrack"]
     active = True
 
     def process(self, instance):
         self.log.debug(f"SATUTS_TO_SET: {instance.data['creator_attributes'].get('ftrack_status')}")
+
+        task = instance.data.get("ftrackTask")
+        name = instance.data.get("name")
+        session = instance.context.data["ftrackSession"]
+
+        # Check if there are any integrated AssetVersion entities
+        asset_versions_key = "ftrackIntegratedAssetVersionsData"
+        asset_versions_key_backwards_compatible = "ftrackIntegratedAssetVersionsData"  # noqa
+        asset_version_data = instance.data.get(
+            asset_versions_key
+        ) or instance.data.get(asset_versions_key_backwards_compatible)
+        if not asset_version_data:
+            asset_version_data = get_asset_version_by_task_id(
+                session,
+                task['id'],
+                name
+            )
+        else:
+            for asset_version in asset_version_data.values():
+                asset_version_data = asset_version["asset_version"]
+
+        if not asset_version_data:
+            self.log.debug("No AssetVersion found")
+            return
+
+        instance_status = instance.data['creator_attributes'].get(
+            'ftrack_status'
+        )
+        asset_version_data["status"] = instance_status
+
+        try:
+            # session.commit()
+            self.log.debug(
+                "Status set to {} for AssetVersion \"{}\" ".format(
+                    instance_status, str(asset_version_data)
+                )
+            )
+        except Exception:
+            tp, value, tb = sys.exc_info()
+            session.rollback()
+            session._configure_locations()
+            six.reraise(tp, value, tb)

--- a/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_instance_status_to_ftrack.py
@@ -1,0 +1,11 @@
+import pyblish.api
+
+
+class IntegrateInstanceStatusToFtrack(pyblish.api.InstancePlugin):
+
+    order = pyblish.api.IntegratorOrder + 0.49
+    label = "Integrate Instance Status To Ftrack"
+    active = True
+
+    def process(self, instance):
+        self.log.debug(f"SATUTS_TO_SET: {instance.data['creator_attributes'].get('ftrack_status')}")

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -515,6 +515,9 @@
         "ftrack_task_status_on_farm_publish": {
             "status_profiles": []
         },
+        "IntegrateInstanceStatusToFtrack": {
+            "enabled": true
+        },
         "IntegrateFtrackTaskStatus": {
             "after_version_statuses": true
         }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -1234,6 +1234,21 @@
                 },
                 {
                     "type": "dict",
+                    "collapsible": true,
+                    "checkbox_key": "enabled",
+                    "key": "IntegrateInstanceStatusToFtrack",
+                    "label": "Integrate Instance Status To Ftrack",
+                    "is_group": true,
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        }
+                    ]
+                },
+                {
+                    "type": "dict",
                     "key": "IntegrateFtrackTaskStatus",
                     "label": "Integrate Ftrack Task Status",
                     "children": [


### PR DESCRIPTION
## Changelog Description
Create a new "ftrack status" attribute for the creators that will set the status of the AssetVersion on ftrack. This attribute is an enum with only available status for the current project schema.

## Testing notes:
1. publish an asset
2. go in the publish instance settings 
3. set the status you want
4. publish
5. go on ftrack to see the status of the asset version changed
