### PR TITLE
#300: enhancement: add custom start frame for tvpaint start frame validator

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/help/validate_start_frame.xml
+++ b/openpype/hosts/tvpaint/plugins/publish/help/validate_start_frame.xml
@@ -2,13 +2,13 @@
 <root>
 <error id="main">
 <title>First frame</title>
-<description>## MarkIn is not set to 0
+<description>## MarkIn is not set to {start_frame_expected}
 
-MarkIn in your scene must start from 0 fram index but MarkIn is set to {current_start_frame}.
+MarkIn in your scene must start from frame {start_frame_expected} but MarkIn is set to {current_start_frame}.
 
 ### How to repair?
 
-You can modify MarkIn manually or hit the "Repair" button on the right which will change MarkIn to 0 (does not change MarkOut).
+You can modify MarkIn manually or hit the "Repair" button on the right which will change MarkIn to {start_frame_expected} (does not change MarkOut).
 </description>
 </error>
 </root>

--- a/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
+++ b/openpype/hosts/tvpaint/plugins/publish/validate_start_frame.py
@@ -14,7 +14,7 @@ class RepairStartFrame(pyblish.api.Action):
     on = "failed"
 
     def process(self, context, plugin):
-        execute_george("tv_startframe 0")
+        execute_george(f"tv_startframe {plugin.start_frame}")
 
 
 class ValidateStartFrame(
@@ -28,19 +28,21 @@ class ValidateStartFrame(
     hosts = ["tvpaint"]
     actions = [RepairStartFrame]
     optional = True
+    start_frame = 0
 
     def process(self, context):
         if not self.is_active(context.data):
             return
 
-        start_frame = execute_george("tv_startframe")
-        if start_frame == 0:
+        scene_start_frame = execute_george("tv_startframe")
+        if scene_start_frame == self.start_frame:
             return
 
         raise PublishXmlValidationError(
             self,
-            "Start frame has to be frame 0.",
+            f"Start frame has to be frame {self.start_frame}.",
             formatting_data={
-                "current_start_frame": start_frame
+                "start_frame_expected": self.start_frame,
+                "current_start_frame": scene_start_frame
             }
         )

--- a/openpype/settings/defaults/project_settings/tvpaint.json
+++ b/openpype/settings/defaults/project_settings/tvpaint.json
@@ -75,7 +75,8 @@
         "ValidateStartFrame": {
             "enabled": false,
             "optional": true,
-            "active": true
+            "active": true,
+            "start_frame": 0
         },
         "ValidateAssetName": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_tvpaint.json
@@ -299,15 +299,33 @@
                     ]
                 },
                 {
-                  "type": "schema_template",
-                  "name": "template_publish_plugin",
-                  "template_data": [
-                      {
-                          "key": "ValidateStartFrame",
-                          "label": "Validate Scene Start Frame",
-                          "docstring": "Validate first frame of scene is set to '0'."
-                      }
-                  ]
+                    "type": "dict",
+                    "key": "ValidateStartFrame",
+                    "label": "Validate Start Frame",
+                    "is_group": true,
+                    "checkbox_key": "enabled",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "optional",
+                            "label": "Optional"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "active",
+                            "label": "Active"
+                        },
+                        {
+                            "type": "text",
+                            "key": "start_frame",
+                            "label": "Start frame"
+                        }
+                    ]
                 },
                 {
                     "type": "schema_template",

--- a/server_addon/tvpaint/server/settings/publish_plugins.py
+++ b/server_addon/tvpaint/server/settings/publish_plugins.py
@@ -117,7 +117,8 @@ DEFAULT_PUBLISH_SETTINGS = {
     "ValidateStartFrame": {
         "enabled": False,
         "optional": True,
-        "active": True
+        "active": True,
+        "start_frame": 0
     },
     "ValidateAssetName": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
Add custom frame input in validate  start frame tvPaint validator.

## Additional info
Extract PSD has been updated to update outputs psd names according to the given start frame, which can now have other values than 0.
Link to the PR : https://github.com/quadproduction/openpype-custom-plugins/pull/33

Fix quadproduction/issues#300

## Testing notes:
1. Open any tvPaint scene
2. Launch scene render, with or without the correct start frame
