### PR TITLE
set correct aspect ratio for the review (quadproduction/issues#255)

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -876,6 +876,56 @@ def get_ffprobe_streams(path_to_file, logger=None):
     """
     return get_ffprobe_data(path_to_file, logger)["streams"]
 
+def get_video_metadata(streams, logger=None):
+    if not logger:
+        logger = logging.getLogger(__name__)
+
+    input_timecode = ""
+    input_width = None
+    input_height = None
+    input_frame_rate = None
+    input_pixel_aspect = None
+    for stream in streams:
+        if stream.get("codec_type") != "video":
+            continue
+        logger.debug("FFprobe Video: {}".format(stream))
+
+        if "width" not in stream or "height" not in stream:
+            continue
+        width = int(stream["width"])
+        height = int(stream["height"])
+        if not width or not height:
+            continue
+
+        # Make sure that width and height are captured even if frame rate
+        #    is not available
+        input_width = width
+        input_height = height
+
+        input_pixel_aspect = stream.get("sample_aspect_ratio")
+        if input_pixel_aspect is not None:
+            try:
+                input_pixel_aspect = float(
+                    eval(str(input_pixel_aspect).replace(':', '/')))
+            except Exception:
+                logger.debug(
+                    "__Converting pixel aspect to float failed: {}".format(
+                        input_pixel_aspect))
+
+        tags = stream.get("tags") or {}
+        input_timecode = tags.get("timecode") or ""
+
+        input_frame_rate = stream.get("r_frame_rate")
+        if input_frame_rate is not None:
+            break
+    return (
+        input_width,
+        input_height,
+        input_timecode,
+        input_frame_rate,
+        input_pixel_aspect
+    )
+
 
 def get_ffmpeg_format_args(ffprobe_data, source_ffmpeg_cmd=None):
     """Copy format from input metadata for output.

--- a/openpype/plugins/publish/extract_review_slate.py
+++ b/openpype/plugins/publish/extract_review_slate.py
@@ -11,6 +11,7 @@ from openpype.lib import (
     get_ffmpeg_tool_args,
     get_ffprobe_data,
     get_ffprobe_streams,
+    get_video_metadata,
     get_ffmpeg_codec_args,
     get_ffmpeg_format_args,
 )
@@ -88,7 +89,7 @@ class ExtractReviewSlate(publish.Extractor):
                 input_timecode,
                 input_frame_rate,
                 input_pixel_aspect
-            ) = self._get_video_metadata(streams)
+            ) = get_video_metadata(streams, self.log)
             if input_pixel_aspect:
                 pixel_aspect = input_pixel_aspect
 
@@ -418,53 +419,6 @@ class ExtractReviewSlate(publish.Extractor):
             ).format(slate_path))
 
         return (slate_width, slate_height)
-
-    def _get_video_metadata(self, streams):
-        input_timecode = ""
-        input_width = None
-        input_height = None
-        input_frame_rate = None
-        input_pixel_aspect = None
-        for stream in streams:
-            if stream.get("codec_type") != "video":
-                continue
-            self.log.debug("FFprobe Video: {}".format(stream))
-
-            if "width" not in stream or "height" not in stream:
-                continue
-            width = int(stream["width"])
-            height = int(stream["height"])
-            if not width or not height:
-                continue
-
-            # Make sure that width and height are captured even if frame rate
-            #    is not available
-            input_width = width
-            input_height = height
-
-            input_pixel_aspect = stream.get("sample_aspect_ratio")
-            if input_pixel_aspect is not None:
-                try:
-                    input_pixel_aspect = float(
-                        eval(str(input_pixel_aspect).replace(':', '/')))
-                except Exception:
-                    self.log.debug(
-                        "__Converting pixel aspect to float failed: {}".format(
-                            input_pixel_aspect))
-
-            tags = stream.get("tags") or {}
-            input_timecode = tags.get("timecode") or ""
-
-            input_frame_rate = stream.get("r_frame_rate")
-            if input_frame_rate is not None:
-                break
-        return (
-            input_width,
-            input_height,
-            input_timecode,
-            input_frame_rate,
-            input_pixel_aspect
-        )
 
     def _get_audio_metadata(self, streams):
         # Get audio metadata


### PR DESCRIPTION
## Changelog Description
Resolved aspect ratio problem on review videos published on Ftrack.

## Additional info
This will not fix the thumbnail issue which is fixed in Openpype 3.17.7 here: https://github.com/ynput/OpenPype/commit/09b3646becdb77f2682a2aa8f148e3816bd58c95

## Testing notes:
1. As you should test it on the farm, the most simple way should be applying the modification of this PR to the code that locates here inside your home directory: ~/.local/share/openpype/[YOUR_OPENPYPE_VERSION]
2. you can delete checksums file if there is any error concerning this file.
3. publish this test scene (project: LA_FIEVRE_P2_23_52, Shots: 990_0020, task: compo) 
4. verify reviews on Ftrack.
