### PR TITLE
Enhancement/299 enhancement ajouter la slection de layer lors de la prparation de rendus deadline

### DIFF
--- a/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
+++ b/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
@@ -122,14 +122,20 @@ def populate_render_properties(dummy=None):
 
 
 def collect_render_layers():
-        for render_layer_name in get_render_layers_names():
-            item = bpy.context.window_manager.render_layers_to_use.add()
-            item.name = render_layer_name
-            item.value = bpy.context.scene.view_layers[render_layer_name].use
+    bpy.context.window_manager.render_layers_to_use.clear()
+    for render_layer_name in get_render_layers_names():
+        item = bpy.context.window_manager.render_layers_to_use.add()
+        item.name = render_layer_name
+        item.value = bpy.context.scene.view_layers[render_layer_name].use
 
 
 def render_layers_needs_update():
-    return len(bpy.context.window_manager.render_layers_to_use) != len(get_render_layers_names())
+    return set(
+        [
+            render_layer.name for render_layer in
+            bpy.context.window_manager.render_layers_to_use
+        ]
+    ) != set(get_render_layers_names())
 
 
 class RenderBoolProperty(bpy.types.PropertyGroup):

--- a/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
+++ b/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
@@ -172,7 +172,7 @@ class PrepareAndRenderScene(bpy.types.Panel):
             col.prop(render_property, 'items', text=render_property.name)
 
         col = layout.box()
-        col.label(text="Render layers to activate")
+        col.label(text="Render layers to use")
         if render_layers_needs_update():
             collect_render_layers()
 

--- a/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
+++ b/openpype/hosts/blender/blender_addon/addons/DeadlineBlenderScenePrepare.py
@@ -357,17 +357,6 @@ def register():
     bpy.types.WindowManager.render_bool_properties = bpy.props.CollectionProperty(type=RenderBoolProperty)
     bpy.types.WindowManager.render_list_properties = bpy.props.CollectionProperty(type=RenderListProperty)
     bpy.types.WindowManager.render_layers_to_use = bpy.props.CollectionProperty(type=RenderLayerProperty)
-    # bpy.types.WindowManager.render_layers = bpy.props.EnumProperty(
-    #     name = "Render layers",
-    #     description ="Render layers to ",
-    #     items = ('Test', 'Test', 'Test')#get_render_layers_names
-    # )
-    #))
-
-        # name="Render layers",
-        # description="Render layers",
-        # items=get_render_layers_names
-    #)
 
     ExecutionOrder.define("DEADLINE_OT_prepare_temporary_scene")
     ExecutionOrder.define("OPS_OT_submit_blender_to_deadline")


### PR DESCRIPTION
## Changelog Description
Add selection layer to enable or disable render layers when preparing scene for rendering with Deadline.

Fix quadproduction/issues#299

## Testing notes:
1. Open a Blender scene
2. Launch a render with the custom addon, located on the 3D View
3. When the Deadline's addon opens, you can simply open the temporary scene (given in the addon input) to check that the correct layers has been updated.
