### PR TITLE
Add more filters to ftrack query which identify asset where publish the annotation

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -360,6 +360,8 @@ def add_rv_from_presets():
 
     app_manager = ApplicationManager()
     openrv_app = app_manager.find_latest_available_variant_for_group("openrv")
+    if not openrv_app:
+        return
     rv_exec_path = str(openrv_app.find_executable())
     rv_root = os.path.dirname(os.path.dirname(rv_exec_path))
     rv_nuke_path = os.path.join(rv_root, 'plugins', 'SupportFiles', 'rvnuke')

--- a/openpype/hosts/openrv/plugins/publish/extract_annotations.py
+++ b/openpype/hosts/openrv/plugins/publish/extract_annotations.py
@@ -5,6 +5,7 @@ import ftrack_api
 import rv
 
 from openpype.pipeline import publish
+from openpype.client import get_project
 from openpype.hosts.openrv.api.review import (
     get_path_annotated_frame,
     extract_annotated_frame
@@ -63,7 +64,14 @@ class ExtractOpenRVAnnotatedFrames(publish.Extractor):
         user = session.query("User where username is \"{}\"".format(session.api_user)).first()
 
         # Get the target entity
-        asset_version = session.query('AssetVersion where asset.name is "{0}" and version is {1}'.format(version_context['subset'], version_context['version'])).one()
+        project_id = get_project(version_context['project']['name'])['data']['ftrackId']
+        asset_query = ('AssetVersion where asset.name is "{0}"'
+                       ' and version is {1} and project_id is {2} '
+                       'and asset.parent.name is {3}').format(version_context['subset'],
+                                                              version_context['version'],
+                                                              project_id,
+                                                              version_context['asset'])
+        asset_version = session.query(asset_query).one()
 
         # Set up note details
         properties_name = "{0}.openpype_review.comment".format(node)


### PR DESCRIPTION
## Changelog Description
Ftrack request was too soft to identify the correct asset in ftrack database, I've added project_ftrack_id, asset_parent_name parameters in the request, this fix the issue linked to this [ticket](https://github.com/quadproduction/issues/issues/222).

I also added a check in order the open_rv app will be none blockable during the nuke launcher.

## Testing notes:
1. In Ftrack, go to MISKINA_S02_23_19 > Shots > 201 > 201_106
2. Click on Open wih RV
3. Draw an annotation ('F10' shortcu) 
4. Publish
5. Go in Ftrack, and you should see your annotation
6. Delete your annotation 