### PR TITLE
Fix Rolex look export and assign problems

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -538,6 +538,9 @@ def attribute_values(attr_values):
     original = [(attr, cmds.getAttr(attr)) for attr in attr_values]
     try:
         for attr, value in attr_values.items():
+            if not cmds.getAttr(attr ,settable=True):
+                log.debug("can not set {}".format(attr))
+                continue
             if isinstance(value, string_types):
                 cmds.setAttr(attr, value, type="string")
             else:
@@ -545,6 +548,9 @@ def attribute_values(attr_values):
         yield
     finally:
         for attr, value in original:
+            if not cmds.getAttr(attr ,settable=True):
+                log.debug("can not set {}".format(attr))
+                continue
             if isinstance(value, string_types):
                 cmds.setAttr(attr, value, type="string")
             elif value is None and cmds.getAttr(attr, type=True) == "string":
@@ -1535,7 +1541,11 @@ def set_attribute(attribute, value, node):
     """
 
     value_type = type(value).__name__
-    kwargs = ATTRIBUTE_DICT[value_type]
+    kwargs = ATTRIBUTE_DICT.get(value_type)
+    if not kwargs:
+        log.debug("Attribute type is not supported for {}".format(attribute))
+        return
+
     if not cmds.attributeQuery(attribute, node=node, exists=True):
         log.debug("Creating attribute '{}' on "
                   "'{}'".format(attribute, node))


### PR DESCRIPTION
## Changelog Description
This fix Rolex look export and assignment problems. 

## Testing notes:
1. Try to export a look from this scene: project: RLX_NOVELTIES_2024_23_62 -> WATCHES -> SKY_DWELLER -> M336935_0004 -> reference -> M336935_0004_reference_v005.ma
2. Then open an empty scene here : RLX_NOVELTIES_2024_23_62 -> 800 -> 800_0060 -> animation
3. load the point cache and apply the exported look via Look Manager.