### PR TITLE
Fix Prepare Project

### DIFF
--- a/openpype/client/mongo/operations.py
+++ b/openpype/client/mongo/operations.py
@@ -606,6 +606,8 @@ def create_project(
     #   and Anatomy
     try:
         project_settings_entity = ProjectSettings(project_name)
+        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
+        project_settings_entity["project_anatomy"]._current_metadata["bypass_protect_anatomy_attributes"] = True
         project_settings_entity.save()
     except SaveWarningExc as exc:
         print(str(exc))

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -405,8 +405,6 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
-        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
-        project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -405,6 +405,7 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
+        project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}
         attributes_entity = project_anatomy_settings["attributes"]

--- a/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py
@@ -405,6 +405,7 @@ class PrepareProjectLocal(BaseAction):
         project_settings = ProjectSettings(project_name)
         project_anatomy_settings = project_settings["project_anatomy"]
         project_anatomy_settings["roots"] = root_data
+        # Add a flag to be able to bypass the enabled protection for the anatomy attrs
         project_anatomy_settings._current_metadata["bypass_protect_anatomy_attributes"] = True
 
         custom_attribute_values = {}


### PR DESCRIPTION
## Changelog Description
The issue is the "bypass_protect_anatomy_attributes" arguments was setted too late, so when the Prepare Project Action execute this [create_project(project_name, project_code)](https://github.com/quadproduction/OpenPype/blob/f17e221e4b0601598abe8e90a6d7a3e2334616dd/openpype/modules/ftrack/event_handlers_user/action_prepare_project.py#L399C13-L399C27), it actually calls the mongo client [create_project()
](https://github.com/quadproduction/OpenPype/blob/f17e221e4b0601598abe8e90a6d7a3e2334616dd/openpype/client/mongo/operations.py#L545) which actually save project settings, but as at this point the "bypass_protect_anatomy_attributes" was not setted, that's explain why it was not possible to write any data in ftrack.

## Testing notes:
1. Create a new project on Ftrack
2. Do the Prepare Project action on the new project
3. Check if the attributes are correctly set