### PR TITLE
#333: bugfix: changement de la recup de valeur fps des settings

### DIFF
--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -47,13 +47,17 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
             collection = collections[0]
             repres_frames = list(collection.indexes)
 
-            try:
-                fps = instance.context.data["assetEntity"]["data"]["fps"]
-            except KeyError:
-                try:
-                    fps = instance.context.data["projectEntity"]["data"]["fps"]
-                except KeyError:
-                    fps = None
+            fps = None
+            # Try to retrieve the fps value from asset else project
+            if "assetEntity" in instance.context.data:
+                fps = instance.context.data["assetEntity"]["data"].get("fps", None)
+            elif "projectEntity" in instance.context.data:
+                fps = instance.context.data["projectEntity"]["data"].get("fps", None)
+
+            if fps is None:
+                self.log.warning("Cannot properly retrieve the FPS value.")
+                # Assign a default value to avoid Kitsu error
+                fps = 25
 
             return {
                 "frameStart": repres_frames[0],

--- a/openpype/plugins/publish/collect_sequence_frame_data.py
+++ b/openpype/plugins/publish/collect_sequence_frame_data.py
@@ -47,10 +47,18 @@ class CollectSequenceFrameData(pyblish.api.InstancePlugin):
             collection = collections[0]
             repres_frames = list(collection.indexes)
 
+            try:
+                fps = instance.context.data["assetEntity"]["data"]["fps"]
+            except KeyError:
+                try:
+                    fps = instance.context.data["projectEntity"]["data"]["fps"]
+                except KeyError:
+                    fps = None
+
             return {
                 "frameStart": repres_frames[0],
                 "frameEnd": repres_frames[-1],
                 "handleStart": 0,
                 "handleEnd": 0,
-                "fps": instance.context.data["assetEntity"]["data"]["fps"]
+                "fps": fps
             }


### PR DESCRIPTION
## Changelog Description
Fix quadproduction/issues#333
Change the method to retrieve the fps info to avoid blocking collect step while publishing sequence image with the standalone.

## Testing notes:
1. Open the standAlone publisher
2. Create a publish for a render by dropping a sequence of image in the correct window
3. publish it