### PR TITLE
Enhancement: be able to use the workfile name in the template of the deadline job name and batch name

### DIFF
--- a/openpype/modules/deadline/utils.py
+++ b/openpype/modules/deadline/utils.py
@@ -23,6 +23,7 @@ def set_custom_deadline_name(instance, filename, setting):
     anatomy_data = context.data.get("anatomyData")
 
     formatting_data = {
+        "workfile": basename,
         "asset": anatomy_data.get("asset"),
         "task": anatomy_data.get("task"),
         "subset": instance.data.get("subset"),

--- a/website/docs/module_deadline.md
+++ b/website/docs/module_deadline.md
@@ -37,6 +37,7 @@ Here's the keys you can use for your batch name
 
 | Context key     | Description                                      |
 |-----------------|--------------------------------------------------|
+| `workfile`      | Workfile name without the extension              |
 | `project[name]` | Project's full name                              |
 | `project[code]` | Project's code                                   |
 | `asset`         | Name of asset or shot                            |


### PR DESCRIPTION
## Changelog Description
I added a "workfile" key in the possible keys of the template for the deadline batch name and job name. The "workfile" key corresponds to the name of the current workfile without the extension.

## Testing notes:
1. go in the deadline batch name and job name settings
2. add the "workfile" key in the template
3. send a job to deadline
4. go to your job in deadline and see the workfile name in the batch name or job name
