### PR TITLE
Enhancement: possibility to deactivate animation instance at creation with workfile template builder

### DIFF
--- a/openpype/hosts/maya/api/lib.py
+++ b/openpype/hosts/maya/api/lib.py
@@ -4192,8 +4192,11 @@ def create_rig_animation_instance(
     # Create the animation instance
     with maintained_selection():
         cmds.select([output, controls] + roots, noExpand=True)
-        create_context.create(
+        new_context = create_context.create(
             creator_identifier=creator_identifier,
             variant=namespace,
             pre_create_data={"use_selection": True}
         )
+    subset = new_context.get("subset", None)
+
+    return subset

--- a/openpype/hosts/maya/plugins/load/load_reference.py
+++ b/openpype/hosts/maya/plugins/load/load_reference.py
@@ -230,11 +230,14 @@ class ReferenceLoader(openpype.hosts.maya.api.plugin.ReferenceLoader):
         self._lock_camera_transforms(members)
 
     def _post_process_rig(self, namespace, context, options):
-
         nodes = self[:]
-        create_rig_animation_instance(
+        animation_instance = create_rig_animation_instance(
             nodes, context, namespace, options=options, log=self.log
         )
+        if animation_instance:
+            active = options.get("active")
+            if active is not None:
+                cmds.setAttr("{}.active".format(animation_instance), active)
 
     def _lock_camera_transforms(self, nodes):
         cameras = cmds.ls(nodes, type="camera")


### PR DESCRIPTION
## Changelog Description
Add the possibility to add an "active" argument type bool to activate or deactivate an animation instance at creation with the workfile template builder.

## Testing notes:
1. go in the desired placeholder creation interface
2. in the "Loader Arguments" entry, add `"active":False`
3. go in an empty scene and start the "Build Workfile from template"
4. select your animation instance and see that it is deactivate
