### PR TITLE
Excluded sets with pre-defined suffixes from collected look sets

### DIFF
--- a/openpype/hosts/maya/plugins/publish/validate_look_sets.py
+++ b/openpype/hosts/maya/plugins/publish/validate_look_sets.py
@@ -46,6 +46,8 @@ class ValidateLookSets(pyblish.api.InstancePlugin):
     label = 'Look Sets'
     actions = [openpype.hosts.maya.api.action.SelectInvalidAction]
 
+    exclude_sets_with_suffix = []
+
     def process(self, instance):
         """Process all the nodes in the instance"""
 
@@ -66,6 +68,12 @@ class ValidateLookSets(pyblish.api.InstancePlugin):
             for node in instance:
                 # get the connected objectSets of the node
                 sets = lib.get_related_sets(node)
+
+                # exclude sets with suffix from the settings
+                for set in sets:
+                    if set.endswith(tuple(cls.exclude_sets_with_suffix)):
+                        sets.pop(sets.index(set))
+
                 if not sets:
                     continue
 

--- a/openpype/settings/defaults/project_settings/maya.json
+++ b/openpype/settings/defaults/project_settings/maya.json
@@ -1203,6 +1203,9 @@
             "optional": false,
             "validate_shapes": true
         },
+        "ValidateLookSets": {
+            "exclude_sets_with_suffix": []
+        },
         "ExtractPlayblast": {
             "capture_preset": {
                 "Codec": {

--- a/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
+++ b/openpype/settings/entities/schemas/projects_schema/schemas/schema_maya_publish.json
@@ -910,6 +910,20 @@
             ]
         },
         {
+            "type": "dict",
+            "collapsible": true,
+            "key": "ValidateLookSets",
+            "label": "Validate Look Sets",
+            "children": [
+                {
+                    "key": "exclude_sets_with_suffix",
+                    "label": "Exclude Sets With Suffix",
+                    "type": "list",
+                    "object_type": "text"
+                }
+            ]
+        },
+        {
             "type": "splitter"
         },
         {


### PR DESCRIPTION
## Changelog Description
Excluded user-defined sets with pre-defined suffixes from collected look sets

## Testing notes:
1. Run the code in the development environment (opdev). Add a custom suffix (for example, `RLX`) to the project settings for the RLX_NOVELTIES_2024_23_62 project located at `project_settings/maya/publish/ValidateLookSets/exclude_sets_with_suffix/`.
2. Open this scene: Project: RLX_NOVELTIES_2024_23_62 -> WATCHES -> SKY_DWELLER -> M336935_0004 -> Reference -> M336935_0004_reference_v005.ma.
3. Check if there are sets created by the user. There is already one named setBordVerre_RLX.
4. Open the publish interface and validate. (To verify everything is correct, you can remove `RLX` from the end of the set name and retry the validation process.)
