### PR TITLE
Enhancement: add an old script from shotgun pipeline for Hiero

### DIFF
--- a/openpype/hosts/hiero/api/startup/Python/StartupUI/add_resolve_entries.py
+++ b/openpype/hosts/hiero/api/startup/Python/StartupUI/add_resolve_entries.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+"""
+Add user resolve entries
+==============================
+
+"""
+
+# Import depandencies
+import hiero.core  # noqa
+
+
+def global_add_resolve_entries(self, resolver):
+
+    # Get resolution
+    def get_resolution(task):
+        if hasattr(task._item, 'source'):
+            width = task._item.source().mediaSource().width()
+            height = task._item.source().mediaSource().height()
+        else:
+            current = task._sequence if task._sequence else task._clip
+            width = current.format().width()
+            height = current.format().height()
+        return str(width), str(height)
+
+    # Add resolver for width
+    resolver.addResolver(
+        "{width}",
+        "Returns the width of the source plate",
+        lambda keyword, task: get_resolution(task)[0]
+    )
+
+    # Add resolver for height
+    resolver.addResolver(
+        "{height}",
+        "Returns the height of the source plate",
+        lambda keyword, task: get_resolution(task)[1]
+    )
+
+
+# This token can be applied to ANY export so add it to the base class
+hiero.core.TaskPresetBase.addUserResolveEntries = global_add_resolve_entries


### PR DESCRIPTION
## Changelog Description
Add the add_resolve_entries.py script to Hiero that adds new variables "height" and "width" to the exports path in Hiero.

## Testing notes:
1. open the export window in Hiero
2. hover the shot in the "Export Structure" module
3. check if "height" and "width" are in the available variables

![image](https://github.com/quadproduction/OpenPype/assets/51854004/8615f4ce-7fb0-4d74-b21f-e0a9e83f8856)

