### PR TITLE
[OpenRV] Fix double publish issue in ftrack 

### DIFF
--- a/openpype/hosts/openrv/api/lib.py
+++ b/openpype/hosts/openrv/api/lib.py
@@ -40,8 +40,4 @@ def clean_rv_sources():
     """
     Clean all sources showed in RV
     """
-    view_nodes = rv.commands.viewNodes()
-    for view_node in view_nodes:
-        if 'default' in view_node.lower():
-            continue
-        rv.commands.deleteNode(view_node)
+    rv.commands.clearSession()

--- a/openpype/hosts/openrv/plugins/create/create_annotations.py
+++ b/openpype/hosts/openrv/plugins/create/create_annotations.py
@@ -36,11 +36,6 @@ class AnnotationCreator(AutoCreator):
     def collect_instances(self):
 
         project_name = get_current_project_name()
-
-        # Query the representations in one go (optimization)
-        # TODO: We could optimize more by first checking annotated frames
-        #   and then only query the representations for those containers
-        #   that have any annotated frames.
         containers = list(get_containers())
         if not containers:
             if not rv.commands.sources():

--- a/openpype/hosts/openrv/plugins/load/load_frames.py
+++ b/openpype/hosts/openrv/plugins/load/load_frames.py
@@ -32,9 +32,7 @@ class FramesLoader(load.LoaderPlugin):
 
     def load(self, context, name=None, namespace=None, data=None):
 
-        filepath = self._format_path(context)
-        # Command fails on unicode so we must force it to be strings
-        filepath = str(filepath)
+        filepath = str(self._format_path(context))
 
         clean_rv_sources()
         rv.commands.addSourceVerbose([filepath])
@@ -44,14 +42,12 @@ class FramesLoader(load.LoaderPlugin):
         os.environ["AVALON_PROJECT"] = context["project"]["name"]
         os.environ["AVALON_ASSET"] = context["asset"]["name"]
         os.environ["AVALON_TASK"] = context["representation"]["context"]["task"]["name"]
-        rv.commands.addSourceVerbose([filepath])
 
     def update(self, container, representation):
         node = container["node"]
 
         context = get_representation_context(representation)
-        filepath = self._format_path(context)
-        filepath = str(filepath)
+        filepath = str(self._format_path(context))
 
         # change path
         rv.commands.setSourceMedia(node, [filepath])

--- a/openpype/hosts/openrv/plugins/load/load_mov.py
+++ b/openpype/hosts/openrv/plugins/load/load_mov.py
@@ -28,9 +28,7 @@ class MovLoader(load.LoaderPlugin):
 
     def load(self, context, name=None, namespace=None, data=None):
 
-        filepath = self.fname
-        # Command fails on unicode so we must force it to be strings
-        filepath = str(filepath)
+        filepath = str(self.fname)
 
         clean_rv_sources()
         rv.commands.addSourceVerbose([filepath])
@@ -40,14 +38,12 @@ class MovLoader(load.LoaderPlugin):
         os.environ["AVALON_PROJECT"] = context["project"]["name"]
         os.environ["AVALON_ASSET"] = context["asset"]["name"]
         os.environ["AVALON_TASK"] = context["representation"]["context"]["task"]["name"]
-        rv.commands.addSourceVerbose([filepath])
 
     def update(self, container, representation):
         node = container["node"]
 
         context = get_representation_context(representation)
-        filepath = load.get_representation_path_from_context(context)
-        filepath = str(filepath)
+        filepath = str(load.get_representation_path_from_context(context))
 
         # change path
         rv.commands.setSourceMedia(node, [filepath])


### PR DESCRIPTION
## Changelog Description
There was an error in the load Class(), where we called this commands twice : `rv.commands.addSourceVerbose([filepath])`, it's fixed now
Also, I've updated some part of the codes, in order to be more efficient in the loading process

## Testing notes:
1. Launch OpenRV with any context
2. 'Load Frames' action in the Asset Loader
3. Now, you'll have only one source instead of 2, like this : 
![image](https://github.com/quadproduction/OpenPype/assets/134272390/f9e89f6a-47a1-4952-889e-53031f5d7132)
