### PR TITLE
Bugfix: rename renderlayer instance if the layer name is changed

### DIFF
--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -80,7 +80,7 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
         context = instance.context
 
         layer = instance.data["transientData"]["layer"]
-        # objset = instance.data.get("instance_node")
+        objset = instance.data.get("instance_node")
         filepath = context.data["currentFile"].replace("\\", "/")
         workspace = context.data["workspaceDir"]
 
@@ -92,7 +92,13 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             self.log.warning(msg)
 
         # detect if there are sets (subsets) to attach render to
-        sets = cmds.sets("renderingMain", query=True) or []
+        object_set = None
+        connections = cmds.listConnections(objset)
+        for connection in connections:
+            if cmds.objectType(connection) == "objectSet":
+                object_set = connection
+
+        sets = cmds.sets(object_set, query=True) or []
         attach_to = []
 
         for s in sets:
@@ -116,7 +122,6 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             self.log.debug(" -> attach render to: {}".format(s))
 
         layer_name = layer.name()
-        self.log.debug(f"LAYER_NAME: {layer_name}")
 
         # collect all frames we are expecting to be rendered
         # return all expected files for all cameras and aovs in given

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -105,6 +105,7 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             if not cmds.attributeQuery("family", node=s, exists=True):
                 continue
 
+            # Rename in Maya outliner the set (if needed) with the correct render layer name
             set_layer_name = s.split(":")[-1]
             layer_name = cmds.listConnections(f"{s}.renderlayer")[0]
             if layer_name != set_layer_name:


### PR DESCRIPTION
## Changelog Description
When renaming a layer, rename also the renderlayer instance in the outliner when collecting the render layers.

## Testing notes:
1. create an animation instance
2. rename the associated layer
3. click the validate button in the publisher
4. the render instance in the outliner is renamed
