### PR TITLE
#341: bugfix: use get instead of direct access when retrieving ftp data

### DIFF
--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -48,6 +48,7 @@ class SFTPHandler(AbstractProvider):
             )
             return
 
+        # store to instance for reconnect
         self.sftp_host = presets.get("sftp_host", "")
         self.sftp_port = presets.get("sftp_port", 22)
         self.sftp_user = presets.get("sftp_user", "")

--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -48,12 +48,6 @@ class SFTPHandler(AbstractProvider):
             )
             return
 
-        # store to instance for reconnect
-        if not presets.get('sftp_host'):
-            self.log.warning(
-                "Sync Server: There are no presets for {}.".format(site_name)
-            )
-            return
         self.sftp_host = presets.get("sftp_host", "")
         self.sftp_port = presets.get("sftp_port", 22)
         self.sftp_user = presets.get("sftp_user", "")

--- a/openpype/modules/sync_server/providers/sftp.py
+++ b/openpype/modules/sync_server/providers/sftp.py
@@ -49,12 +49,17 @@ class SFTPHandler(AbstractProvider):
             return
 
         # store to instance for reconnect
-        self.sftp_host = presets["sftp_host"]
-        self.sftp_port = presets["sftp_port"]
-        self.sftp_user = presets["sftp_user"]
-        self.sftp_pass = presets["sftp_pass"]
-        self.sftp_key = presets["sftp_key"]
-        self.sftp_key_pass = presets["sftp_key_pass"]
+        if not presets.get('sftp_host'):
+            self.log.warning(
+                "Sync Server: There are no presets for {}.".format(site_name)
+            )
+            return
+        self.sftp_host = presets.get("sftp_host", "")
+        self.sftp_port = presets.get("sftp_port", 22)
+        self.sftp_user = presets.get("sftp_user", "")
+        self.sftp_pass = presets.get("sftp_pass", "")
+        self.sftp_key = presets.get("sftp_key", "")
+        self.sftp_key_pass = presets.get("sftp_key_pass", "")
 
         self._tree = None
 


### PR DESCRIPTION
## Changelog Description
Update code to use getter instead of direct access when retrieving SFTP informations for Wizz.

fix quadproduction/issues#341

## Additional info
OpenPype was trying to initialize sftp before having the necessary informations. By doing so, it completely broke the SFTPHandler. By checking if the correct value is initialized, the SFTPHandler get correctly updated after.

## Testing notes:
1. Open the loader
2. Download any file
3. Check Sync queue
