### PR TITLE
Fix blocking issue on Deadline EnumEntities

### DIFF
--- a/openpype/modules/deadline/deadline_module.py
+++ b/openpype/modules/deadline/deadline_module.py
@@ -109,6 +109,9 @@ class DeadlineModule(OpenPypeModule, IPluginPaths):
             RuntimeError: If deadline webservice is unreachable.
 
         """
+        if not webservice:
+            return []
+
         if not log:
             log = Logger.get_logger(__name__)
 

--- a/openpype/modules/deadline/utils.py
+++ b/openpype/modules/deadline/utils.py
@@ -110,7 +110,7 @@ def get_deadline_limits_plugin(deadline_enabled, deadline_url, log):
     deadline_module = manager.modules_by_name["deadline"]
 
     limits_plugin = []
-    if deadline_enabled:
+    if deadline_enabled and deadline_url:
         requested_arguments = {"NamesOnly": True}
         limits_plugin = deadline_module.get_deadline_data(
             deadline_url,

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -566,7 +566,7 @@ class DeadlineLimitsPluginEnumEntity(BaseEnumEntity):
 
         modules_system_settings = get_system_settings()["modules"]
         deadline_enabled = modules_system_settings["deadline"]["enabled"]
-        deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default")  # noqa
+        deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default", "")  # noqa
 
         try:
             requests.get(deadline_url)
@@ -656,7 +656,7 @@ class DeadlinePoolsEnumEntity(DynamicEnumEntity):
         if not deadline_enabled:
             return
 
-        deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default")  # noqa
+        deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default", "")  # noqa
         manager = _get_modules_manager()
         deadline_module = manager.modules_by_name["deadline"]
         try:

--- a/openpype/settings/entities/enum_entity.py
+++ b/openpype/settings/entities/enum_entity.py
@@ -1,5 +1,8 @@
 import abc
 import copy
+
+import requests
+
 from .input_entities import InputEntity
 from .exceptions import EntitySchemaError
 from .lib import NOT_SET, STRING_TYPE
@@ -565,11 +568,15 @@ class DeadlineLimitsPluginEnumEntity(BaseEnumEntity):
         deadline_enabled = modules_system_settings["deadline"]["enabled"]
         deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default")  # noqa
 
-        limits_plugin = get_deadline_limits_plugin(
-            deadline_enabled,
-            deadline_url,
-            self.log
-        )
+        try:
+            requests.get(deadline_url)
+            limits_plugin = get_deadline_limits_plugin(
+                deadline_enabled,
+                deadline_url,
+                self.log
+            )
+        except requests.exceptions.ConnectionError:
+            limits_plugin = None
 
         if not limits_plugin:
             return [], set()
@@ -652,7 +659,11 @@ class DeadlinePoolsEnumEntity(DynamicEnumEntity):
         deadline_url = modules_system_settings["deadline"]["deadline_urls"].get("default")  # noqa
         manager = _get_modules_manager()
         deadline_module = manager.modules_by_name["deadline"]
-        pools = deadline_module.get_deadline_pools(deadline_url, self.log)
+        try:
+            requests.get(deadline_url)
+            pools = deadline_module.get_deadline_pools(deadline_url, self.log)
+        except requests.exceptions.ConnectionError:
+            pools = None
 
         if not pools:
             return [], set()


### PR DESCRIPTION
## Changelog Description
As mentionned in this [ticket](https://github.com/quadproduction/issues/issues/341), in case the deadline's url is wrong, it automaticaly raise an Error cause of an [ConnectionError](https://github.com/quadproduction/OpenPype/blob/851b14bde3067c81c3acbca21550f5d27d32de1f/openpype/modules/deadline/deadline_module.py#L121).

I've fixed it by added a pre request which act like a ping on the deadline's url. This will detect if we can get the datas from Deadline API REST, or not. If not, values are automaticaly setted as None.

This fix make also the settings non blocking.
