### PR TITLE
Bugfix: update renderlayer set and renderlayer attributes when layer is renamed

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -506,15 +506,27 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
 
                 subset = cmds.getAttr(f'{node}.subset')
                 if layer.name() not in subset:
-                    self._update_subset(node, layer.name(), subset)
+                    node = self._update_renderlayer_instance(
+                        node,
+                        layer.name(),
+                        subset
+                    )
                 return node
 
-    def _update_subset(self, node, layer_name, subset):
+    def _update_renderlayer_instance(self, node, layer_name, subset):
         variant = cmds.getAttr(f'{node}.variant')
         new_subset_name = subset.replace(variant, layer_name)
 
+        # Update the subset and variant attributes
         cmds.setAttr(f'{node}.subset', new_subset_name, type="string")
         cmds.setAttr(f'{node}.variant', layer_name, type="string")
+
+        # Rename the set to match the new layer name
+        set_layer_name = node.split(":")[-1]
+        new_set_name = node.replace(set_layer_name, layer_name)
+        cmds.rename(node, new_set_name)
+
+        return node
 
     def _create_layer_instance_node(self, layer):
         self.log.debug("#" * 100)

--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -503,10 +503,21 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
             creator_identifier = cmds.getAttr(node + ".creator_identifier")
             if creator_identifier == self.identifier:
                 self.log.info("Found node: {}".format(node))
+
+                subset = cmds.getAttr(f'{node}.subset')
+                if layer.name() not in subset:
+                    self._update_subset(node, layer.name(), subset)
                 return node
 
-    def _create_layer_instance_node(self, layer):
+    def _update_subset(self, node, layer_name, subset):
+        variant = cmds.getAttr(f'{node}.variant')
+        new_subset_name = subset.replace(variant, layer_name)
 
+        cmds.setAttr(f'{node}.subset', new_subset_name, type="string")
+        cmds.setAttr(f'{node}.variant', layer_name, type="string")
+
+    def _create_layer_instance_node(self, layer):
+        self.log.debug("#" * 100)
         # We only collect if a CreateRender instance exists
         create_render_set = self._get_singleton_node()
         if not create_render_set:

--- a/openpype/hosts/maya/plugins/publish/collect_render.py
+++ b/openpype/hosts/maya/plugins/publish/collect_render.py
@@ -92,26 +92,12 @@ class CollectMayaRender(pyblish.api.InstancePlugin):
             self.log.warning(msg)
 
         # detect if there are sets (subsets) to attach render to
-        object_set = None
-        connections = cmds.listConnections(objset)
-        for connection in connections:
-            if cmds.objectType(connection) == "objectSet":
-                object_set = connection
-
-        sets = cmds.sets(object_set, query=True) or []
+        sets = cmds.sets(objset, query=True) or []
         attach_to = []
 
         for s in sets:
             if not cmds.attributeQuery("family", node=s, exists=True):
                 continue
-
-            # Rename in Maya outliner the set (if needed) with the correct render layer name
-            set_layer_name = s.split(":")[-1]
-            layer_name = cmds.listConnections(f"{s}.renderlayer")[0]
-            if layer_name != set_layer_name:
-                new_set_name = s.replace(set_layer_name, layer_name)
-                cmds.rename(s, new_set_name)
-                s = new_set_name
 
             attach_to.append(
                 {


### PR DESCRIPTION
## Changelog Description
Fix the PR https://github.com/quadproduction/OpenPype/pull/675 
Now the renderlayer set is renamed when the publish window is refreshed, same for the "subset" and "variant" attribute of the renderlayer instance.

## Testing notes:
1. rename a layer linked to a renderlayer instance
2. in the publish window hit the reload button
3. check that the set changed name and attributes are modified in the instance
