### PR TITLE
#321: update: return empty list when OpenPype can't retrieve registered instances

### DIFF
--- a/openpype/hosts/blender/plugins/publish/collect_instances.py
+++ b/openpype/hosts/blender/plugins/publish/collect_instances.py
@@ -26,6 +26,9 @@ class CollectInstances(pyblish.api.ContextPlugin):
         and we don't want to publish it.
         """
         instances = bpy.data.collections.get(AVALON_INSTANCES)
+        if not instances:
+            return []
+
         for obj in instances.objects:
             avalon_prop = obj.get(AVALON_PROPERTY) or dict()
             if avalon_prop.get('id') == 'pyblish.avalon.instance':


### PR DESCRIPTION
## Changelog Description
Return empty list when retrieving registered instances.

Fix quadproduction/issues#321

## Additional info
Allow to publish workfile or use validate on scene which doesn't have subset instances.

## Testing notes:
1. Open any empty scene
2. Try to validate or to publish workfile
