### PR TITLE
#374: bugfix: update custom addons install to install user addons eve…

### DIFF
--- a/openpype/hosts/blender/blender_addon/startup/custom_scripts/install_custom_addons.py
+++ b/openpype/hosts/blender/blender_addon/startup/custom_scripts/install_custom_addons.py
@@ -8,33 +8,37 @@ from pathlib import Path
 
 
 def execute():
-    path = get_repository_path("submission/Blender/Client")
     blender_addons_folder_path = get_addons_folder_path()
+    install_deadline_addon(blender_addons_folder_path)
+    enable_user_addons(blender_addons_folder_path)
+    bpy.ops.wm.save_userpref()
+
+
+def install_deadline_addon(blender_addons_folder_path):
+    path = get_repository_path("submission/Blender/Client")
     if not path:
         logging.warning("Can't find Deadline submission repository for Blender. Abort process.")
-        raise ImportError
+        return
 
     deadline_addon_file_name = get_python_addon_file(path)
     deadline_addon_name = Path(deadline_addon_file_name).stem
 
     if _is_already_installed(deadline_addon_name, blender_addons_folder_path):
         logging.info("Deadline addon is already installed")
-    else:
-        try:
-            deadline_addon_path = os.path.join(path, deadline_addon_file_name)
-        except StopIteration:
-            logging.warning("Can't find Deadline submission addon for Blender. Abort process.")
-            raise StopIteration
+        return
 
-        bpy.ops.preferences.addon_install(
-            overwrite=True,
-            filepath=deadline_addon_path
-        )
-        deadline_addon_name = Path(deadline_addon_file_name).stem
-        logging.info("Deadline addon has been correctly installed.")
+    try:
+        deadline_addon_path = os.path.join(path, deadline_addon_file_name)
+    except StopIteration:
+        logging.warning("Can't find Deadline submission addon for Blender. Abort process.")
+        return
 
-    enable_user_addons(blender_addons_folder_path)
-    bpy.ops.wm.save_userpref()
+    bpy.ops.preferences.addon_install(
+        overwrite=True,
+        filepath=deadline_addon_path
+    )
+    deadline_addon_name = Path(deadline_addon_file_name).stem
+    logging.info("Deadline addon has been correctly installed.")
 
 
 def get_python_addon_file(path):


### PR DESCRIPTION
…n if Deadline addon can't be installed

## Changelog Description
Separate deadline install addon from user addons to avoid early exit if deadline addon is not found

## Testing notes:
1. Open any Blender scene
2. Check if all pipe's addons are correctly installed and enabled
