### PR TITLE
#364: enhancement: add normalize option for kitsu review integration

### DIFF
--- a/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/openpype/modules/kitsu/plugins/publish/integrate_kitsu_review.py
@@ -12,6 +12,9 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
     optional = True
 
     def process(self, instance):
+        if not getattr(self, 'enabled', True):
+            return
+
         # Check comment has been created
         comment_id = instance.data.get("kitsu_comment", {}).get("id")
         if not comment_id:
@@ -28,8 +31,8 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
                 continue
             review_path = representation.get("published_path")
             self.log.debug("Found review at: {}".format(review_path))
-
             gazu.task.add_preview(
-                task_id, comment_id, review_path, normalize_movie=True
+                task_id, comment_id, review_path,
+                normalize_movie=getattr(self, 'normalize', True)
             )
             self.log.info("Review upload on comment")

--- a/openpype/settings/defaults/project_settings/kitsu.json
+++ b/openpype/settings/defaults/project_settings/kitsu.json
@@ -16,6 +16,10 @@
                 "enabled": false,
                 "comment_template": "{comment}\n\n|  |  |\n|--|--|\n| version| `{version}` |\n| family | `{family}` |\n| name | `{name}` |"
             }
+        },
+        "IntegrateKitsuReview": {
+            "enabled": true,
+            "normalize": true
         }
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_kitsu.json
@@ -136,6 +136,24 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "IntegrateKitsuReview",
+                    "label": "Integrate Kitsu Review",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "normalize",
+                            "label": "Normalize"
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Changelog Description
Add option in settings to enable and to activate normalization for kitsu review integration.

## Additional info
The modification is designed to also work without these informations in settings.

## Testing notes:
1. Launch any soft which upload a render on Kitsu
2. Check the uploaded file on Kitsu and check for video ratio / size
