### PR TITLE
Add Safety Check For Ftrack module

### DIFF
--- a/start.py
+++ b/start.py
@@ -1094,7 +1094,7 @@ def boot():
         # Get OpenPypeVersion() Object
         op_version_to_extract = prod_dir_version
 
-    if not prod_dir_version and dev_mode:
+    if not prod_dir_version and dev_mode and openpype_path:
         # This isn't a released version, we are in developer mode
         # Generate the version, then copy it on the user/artist directory
 


### PR DESCRIPTION
## Changelog Description
Add Safety check when OPENPYPE_PATH can't be detected. 

Solve this [issue](https://github.com/quadproduction/issues/issues/385), cause the ftrack service has the same command flags that the dev_mode
