### PR TITLE
[Nuke][WorkfileTemplateBuilder] Clean Useless Code 

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1656,7 +1656,6 @@ class PlaceholderLoadMixin(object):
 
         if not placeholder.data.get("keep_placeholder", True):
             self.delete_placeholder(placeholder)
-            self.cleanup_placeholder(placeholder, failed)
 
     def populate_action_placeholder(self, placeholder, repre_load_contexts):
         if "action" not in placeholder.data:


### PR DESCRIPTION
## Changelog Description
La méthode `cleanup_placeholder()` est l'ancien nom de la méthode `delete_placeholder()`.
Elle nécessite d'être supprimé.
