### PR TITLE
404: enhancement: ajout du path vers le psd dans le clipBoard de wind…

### DIFF
--- a/openpype/hosts/aftereffects/plugins/load/load_file.py
+++ b/openpype/hosts/aftereffects/plugins/load/load_file.py
@@ -1,4 +1,6 @@
 import re
+import io
+import subprocess
 
 from openpype.pipeline import get_representation_path
 from openpype.hosts.aftereffects import api
@@ -46,6 +48,10 @@ class FileLoader(api.AfterEffectsLoader):
 
         frame = None
         if '.psd' in path:
+
+            file_folder_path = "/".join(path.split("/")[:-1])
+            self._add_to_clipboard(file_folder_path)
+
             import_options['ImportAsType'] = 'ImportAsType.COMP'
             comp = stub.import_file_with_dialog(path, stub.LOADED_ICON + comp_name)
         else:
@@ -77,6 +83,18 @@ class FileLoader(api.AfterEffectsLoader):
             context,
             self.__class__.__name__
         )
+
+    def _add_to_clipboard(self, path):
+        """Copie le texte dans le presse-papier de Windows (spécifique Windows!)
+        """
+        raw_path = r"{}".format(path)
+        cmd='echo '+path.strip()+'|clip'
+        return subprocess.check_call(cmd, shell=True)
+        """
+        code pour MAC OS:
+        cmd='echo '+txt.strip()+'|pbcopy'
+        return subprocess.check_call(cmd, shell=True)
+        """
 
     def update(self, container, representation):
         """ Switch asset or change version """


### PR DESCRIPTION
…ows afin de le coller directement dans l'explorer de fichier dans AE

Fix quadproduction/issues#404

## Changelog Description
Permet de mettre dans le presse papier de windows le path vers le psd qui est loadé avec OP dans AE. Afin de facilement retrouver dans l'exploreur de fichier où il se trouve et limiter les erreurs

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. Dans AE load un PSD avec OP
2. Dans l'exploreur de fichier window, faire un ctrl+v dans le path afin d'aller au bon dossier correspondant directement
