### PR TITLE
Remove -intra hardcoded flags for ffmpeg processing

### DIFF
--- a/openpype/lib/transcoding.py
+++ b/openpype/lib/transcoding.py
@@ -1071,7 +1071,6 @@ def _ffmpeg_h264_codec_args(stream_data, source_ffmpeg_cmd):
     if pix_fmt:
         output.extend(["-pix_fmt", pix_fmt])
 
-    output.extend(["-intra"])
     output.extend(["-g", "1"])
 
     return output

--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -161,8 +161,7 @@
                                 ],
                                 "output": [
                                     "-pix_fmt yuv420p",
-                                    "-crf 18",
-                                    "-intra"
+                                    "-crf 18"
                                 ]
                             },
                             "filter": {

--- a/server_addon/core/server/settings/publish_plugins.py
+++ b/server_addon/core/server/settings/publish_plugins.py
@@ -807,8 +807,7 @@ DEFAULT_PUBLISH_VALUES = {
                             ],
                             "output": [
                                 "-pix_fmt yuv420p",
-                                "-crf 18",
-                                "-intra"
+                                "-crf 18"
                             ]
                         },
                         "filter": {

--- a/website/docs/pype2/admin_presets_plugins.md
+++ b/website/docs/pype2/admin_presets_plugins.md
@@ -221,8 +221,7 @@ This is just usage example, without relevant data. Do **NOT** use these presets 
                             ],
                             "output": [
                                 "-pix_fmt yuv420p",
-                                "-crf 18",
-                                "-intra"
+                                "-crf 18"
                             ]
                         },
                         "tags": ["burnin", "preview"]


### PR DESCRIPTION
## Changelog Description
Suppression des flags '-intra' étant 'deprecated' depuis notre passage a ffmpeg 6.1-static
