### PR TITLE
[Maya][WorkfileTemplateBuilder] Ignore contex_filter creation when linked_asset are none

### DIFF
--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1504,6 +1504,11 @@ class PlaceholderLoadMixin(object):
             }
 
         elif builder_type == "linked_asset":
+            if not placeholder.data["asset"]:
+                return list(get_representations(
+                    self.project_name,
+                    context_filters={}
+                ))
             asset_regex = re.compile(placeholder.data["asset"])
             linked_asset_names = []
             for asset_doc in linked_asset_docs:

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1504,14 +1504,15 @@ class PlaceholderLoadMixin(object):
             }
 
         elif builder_type == "linked_asset":
-            if not placeholder.data["asset"]:
-                return []
             asset_regex = re.compile(placeholder.data["asset"])
             linked_asset_names = []
             for asset_doc in linked_asset_docs:
                 asset_name = asset_doc["name"]
                 if asset_regex.match(asset_name):
                     linked_asset_names.append(asset_name)
+
+            if not linked_asset_names:
+                return []
 
             context_filters = {
                 "asset": linked_asset_names,

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1505,10 +1505,7 @@ class PlaceholderLoadMixin(object):
 
         elif builder_type == "linked_asset":
             if not placeholder.data["asset"]:
-                return list(get_representations(
-                    self.project_name,
-                    context_filters={}
-                ))
+                return []
             asset_regex = re.compile(placeholder.data["asset"])
             linked_asset_names = []
             for asset_doc in linked_asset_docs:


### PR DESCRIPTION
## Changelog Description
Ignore la création du context_filter lorsque nous sommes en situation d'un template 'linked_asset' et dont la liste est vide dans Ftrack.

Auquel cas, il générait une regex vide dans le context_filter qui venait charger tout les assets disponibles.