### PR TITLE
[Deadline] Add Burnin Management for submit_publish_job.py

### DIFF
--- a/openpype/modules/deadline/common/publish/submit_publish_job.py
+++ b/openpype/modules/deadline/common/publish/submit_publish_job.py
@@ -281,8 +281,8 @@ class ProcessSubmittedJobOnFarm(pyblish.api.InstancePlugin,
             "AuxFiles": [],
         }
 
-        # TODO: Delete this code once the farm will be switch to RockyLinux
-        # TODO: Delete burnin group in Deadline at the same time
+        # TODO: Delete this code once the farm will be fully switched to RockyLinux
+        # TODO: Delete 'burnin' limit in Deadline at the same time
         extract_burnin_data = instance.context.data['project_settings']['global']['publish']['ExtractBurnin']
         if extract_burnin_data['enabled']:
             extract_burnin_mode = False


### PR DESCRIPTION
## Changelog Description
Hello, comme discuté dans ce [ticket(367)](https://github.com/quadproduction/issues/issues/367#issuecomment-2066043781).

Voici une solution qui permet de détecter si le rendu va faire appel a l'ExtractBurnin dans la farm. Le code viendra automatiquement ajouté le limit group 'burnin' au momet du publish si c'est le cas.