### PR TITLE
359: enhancemant: Correction et adaptation du trayPublisher pour publ…

### DIFF
--- a/openpype/hosts/traypublisher/api/editorial.py
+++ b/openpype/hosts/traypublisher/api/editorial.py
@@ -239,10 +239,12 @@ class ShotMetadataSolver:
             visual_hierarchy.append(visual_parent)
             current_doc = visual_parent
 
-        # add current selection context hierarchy
+        # add current selection context hierarchy.
+        # since the entity dict has changed throught OP versions
+        # an adaptation has to be made for it to work for Project types
         return [
             {
-                "entity_type": entity["data"]["entityType"],
+                "entity_type": entity["data"].get("entityType", entity.get("entityType", "Project")),
                 "entity_name": entity["name"]
             }
             for entity in reversed(visual_hierarchy)

--- a/openpype/hosts/traypublisher/plugins/create/create_editorial.py
+++ b/openpype/hosts/traypublisher/plugins/create/create_editorial.py
@@ -203,6 +203,20 @@ or updating already created. Publishing will create OTIO file.
         if self._creator_settings.get("default_variants"):
             self.default_variants = self._creator_settings["default_variants"]
 
+        # set the workfile_start_frame in the settings
+        workfile_start_frame = self._creator_settings["workfile_start_frame"]
+        workfile_start_frame_attr = self._get_attribute_by_name("workfile_start_frame")
+
+        if workfile_start_frame_attr:
+            workfile_start_frame_attr.default = int(workfile_start_frame)
+
+        # switch to auto assign the newly created instance to the corresponding shot
+        # and not the selected one in the publisher window
+        self.auto_asset_assign = self._creator_settings["auto_assign_to_asset"]
+
+        # a switch to add the info that we'll delete or not the clip after review creation
+        self.keep_clip = self._creator_settings["keep_clip"]
+
     def create(self, subset_name, instance_data, pre_create_data):
         allowed_family_presets = self._get_allowed_family_presets(
             pre_create_data)
@@ -569,7 +583,8 @@ or updating already created. Publishing will create OTIO file.
                 "parent_instance_id": parenting_data["instance_id"],
                 "creator_attributes": {
                     "parent_instance": parenting_data["instance_label"],
-                    "add_review_family": preset.get("review")
+                    "add_review_family": preset.get("review"),
+                    "keep_clip": self.keep_clip
                 }
             })
 
@@ -645,8 +660,8 @@ or updating already created. Publishing will create OTIO file.
         fps = instance_data["fps"]
         variant_name = instance_data["variant"]
 
-        # basic unique asset name
-        clip_name = os.path.splitext(otio_clip.name)[0].lower()
+        # basic unique asset name, with no modification of the min/maj syntax
+        clip_name = os.path.splitext(otio_clip.name)[0]
         project_doc = get_project(self.project_name)
 
         shot_name, shot_metadata = self._shot_metadata_solver.generate_data(
@@ -665,6 +680,11 @@ or updating already created. Publishing will create OTIO file.
                 "project_doc": project_doc
             }
         )
+
+        # get the task for asset type
+        task =""
+        if shot_metadata.get('tasks'):
+            task = self._get_task_by_asset_type(parent_asset_name, shot_metadata["tasks"])
 
         self._validate_name_uniqueness(shot_name)
 
@@ -693,8 +713,8 @@ or updating already created. Publishing will create OTIO file.
 
             # HACK: just for temporal bug workaround
             # TODO: should loockup shot name for update
-            "asset": parent_asset_name,
-            "task": "",
+            "asset": shot_name if self.auto_asset_assign else parent_asset_name,
+            "task": task,
 
             "newAssetPublishing": True,
 
@@ -708,6 +728,18 @@ or updating already created. Publishing will create OTIO file.
         base_instance_data.update(shot_metadata)
 
         return base_instance_data
+
+    def _get_task_by_asset_type(self, asset, task_dict):
+        """Return the task assign to the asset type (Shots) to publish the review in
+
+        Args:
+            asset (str): Name of the asset type of the instance.
+            task_dict (dict): dict from the settings to match a task to an asset type.
+
+        Returns:
+            str: task to review
+        """
+        return task_dict[asset]["type"] if asset in task_dict.keys() else ""
 
     def _get_timing_data(
         self,
@@ -872,3 +904,19 @@ or updating already created. Publishing will create OTIO file.
 
         attr_defs.extend(CLIP_ATTR_DEFS)
         return attr_defs
+
+    def _get_attribute_by_name(self, attr_key):
+        """
+        Return the correct attr from CLIP_ATTR_DEFS depending on the given attr_key
+
+        Args:
+            attr_key (str): name of the key attr
+
+        Returns:
+            EnumDef or NumberDef: If one of their key match the attr_key
+        """
+        for attr in CLIP_ATTR_DEFS:
+            if attr.key == attr_key:
+                return(attr)
+
+        return None

--- a/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/openpype/modules/kitsu/plugins/publish/collect_kitsu_entities.py
@@ -27,6 +27,9 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
 
             zou_asset_data = asset_doc["data"].get("zou")
             if not zou_asset_data:
+                #add an exception fo Folder type to avoid blocking the script
+                if asset_doc["data"].get('entityType') == 'Folder':
+                    continue
                 raise ValueError("Zou asset data not found in OpenPype!")
 
             task_name = instance.data.get("task", context.data.get("task"))

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -314,10 +314,6 @@ class ExtractReview(pyblish.api.InstancePlugin):
         layer_name
     ):
         fill_data = copy.deepcopy(instance.data["anatomyData"])
-        from pprint import pprint
-        print ("___________________________________________________________________________")
-        pprint(instance.data)
-        print("___________________________________________________________________________")
 
         for _output_def in output_definitions:
             output_def = copy.deepcopy(_output_def)

--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -90,6 +90,9 @@ class ExtractReview(pyblish.api.InstancePlugin):
         # Make sure cleanup happens and pop representations with "delete" tag.
         for repre in tuple(instance.data["representations"]):
             tags = repre.get("tags") or []
+            # must create a security to not delete the clip as set by default when reviewing with ftrack
+            if instance.data.get('creator_attributes', {}).get('keep_clip') and "delete" in tags:
+                tags.remove("delete")
             if "delete" in tags and "thumbnail" not in tags:
                 instance.data["representations"].remove(repre)
 
@@ -311,6 +314,11 @@ class ExtractReview(pyblish.api.InstancePlugin):
         layer_name
     ):
         fill_data = copy.deepcopy(instance.data["anatomyData"])
+        from pprint import pprint
+        print ("___________________________________________________________________________")
+        pprint(instance.data)
+        print("___________________________________________________________________________")
+
         for _output_def in output_definitions:
             output_def = copy.deepcopy(_output_def)
             # Make sure output definition has "tags" key

--- a/openpype/settings/defaults/project_settings/traypublisher.json
+++ b/openpype/settings/defaults/project_settings/traypublisher.json
@@ -280,6 +280,9 @@
             "default_variants": [
                 "Main"
             ],
+            "workfile_start_frame": 1001,
+            "auto_assign_to_asset": false,
+            "keep_clip": false,
             "clip_name_tokenizer": {
                 "_sequence_": "(sc\\d{3})",
                 "_shot_": "(sh\\d{3})"

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_traypublisher.json
@@ -129,6 +129,23 @@
                             }
                         },
                         {
+                            "type": "text",
+                            "key": "workfile_start_frame",
+                            "label": "Workfile Start Frame"
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "auto_assign_to_asset",
+                            "label": "Auto Asset Assign",
+                            "default": false
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "keep_clip",
+                            "label": "Don't Delete Clip When Review",
+                            "default": false
+                        },
+                        {
                             "type": "splitter"
                         },
                         {


### PR DESCRIPTION
…ier l'animatic dans le pipe et kitsu
Fix quadproduction/issues#359

## Changelog Description
Permet d'utiliser le stand alone publisher pour mettre dans le pipe et sur kitsu l'animatic automatiquement découpé à partir d'un edl et d'une vidéo.
L'audio sera également mis dans le pipe.

Certains settings ont été ajoutés afin d'assurer une rétrocompatibilité et également ne pas bloquer Fix

## Additional info
Paragraphs of text giving context of additional technical information or code examples.

## Testing notes:
1. Dans le stand alone publisher, selectionner le folder Shots d'un projet
2. Et aller dans l'option Editorial Simple
3. Utiliser l'edl et mp4 ici pour test: L:\2023\PROJET_ZERO_KITSU_OP_23_21\04_EDIT\ANIMATIC
4. Creer une plate et un audio
5. publish
