### PR TITLE
#371: bugfix: set frame range from 0 at export instead of given frame…

### DIFF
--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -242,6 +242,8 @@ class ExtractSequence(pyblish.api.Extractor):
             "export_path = \"{}\"".format(
                 first_frame_filepath.replace("\\", "/")
             ),
+            # TvPaint seems to consider software markin as frame 0. If we set a frame start at export,
+            # it will add the frame start to the markin frame and will add an offset for the rest of the export.
             "tv_projectsavesequence '\"'export_path'\"' \"{}\" {} {}".format(
                 export_type, 0, mark_out - mark_in
             )

--- a/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
+++ b/openpype/hosts/tvpaint/plugins/publish/extract_sequence.py
@@ -243,7 +243,7 @@ class ExtractSequence(pyblish.api.Extractor):
                 first_frame_filepath.replace("\\", "/")
             ),
             "tv_projectsavesequence '\"'export_path'\"' \"{}\" {} {}".format(
-                export_type, mark_in, mark_out
+                export_type, 0, mark_out - mark_in
             )
         ]
 


### PR DESCRIPTION
… start and end

## Changelog Description
Update tvPaint export to begin at frame 0 and end at frame range.

⚠️**Needs to be merged with this other PR : https://github.com/quadproduction/openpype-custom-plugins/pull/50**

## Additional info
TvPaint seems to considers software markin as frame 0. If we set a frame start at export, tvPaint will add the frame start to the markin frame, and will create an offset for the rest of the export.

## Testing notes:
1. Open any tvPaint scene
2. Trigger publish playblast publish layout (or publish frame as his new name)
