### PR TITLE
419: enhancement: temp fix pour supprimer le set de res auto

### DIFF
--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2597,7 +2597,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
     def set_context_settings(self):
         os.environ["OP_NUKE_SKIP_SAVE_EVENT"] = "True"
         # replace reset resolution from avalon core to pype's
-        self.reset_resolution()
+        #self.reset_resolution()
         # replace reset resolution from avalon core to pype's
         self.reset_frame_range_handles()
         # add colorspace menu item


### PR DESCRIPTION
Fix quadproduction/issues#419

## Changelog Description
 temp fix pour supprimer le set de res automatique sur Nuke afin de débloquer le comp artiste en attendant un traitement plus complet de ce ticket.

