### PR TITLE
staging/3.16.9-quad-1.12.0-bypass-resolution-reset

### DIFF
--- a/openpype/hosts/blender/blender_addon/addons/libs/paths.py
+++ b/openpype/hosts/blender/blender_addon/addons/libs/paths.py
@@ -57,7 +57,7 @@ def _get_latest_version_folder(filepath, absolute_path=False, create_version_fol
 
 
 def _get_version_directory(filepath):
-    capture_version = r'(.*?)(v\d{3})|(.+[\\\/])'
+    capture_version = r'(.*?)(v\d{3})|(.+)'
     captured_groups = re.search(capture_version, filepath).groups()
     try:
         return Path(next(filter(lambda path: path is not None, captured_groups)))

--- a/openpype/hosts/nuke/api/lib.py
+++ b/openpype/hosts/nuke/api/lib.py
@@ -2597,7 +2597,7 @@ Reopening Nuke should synchronize these paths and resolve any discrepancies.
     def set_context_settings(self):
         os.environ["OP_NUKE_SKIP_SAVE_EVENT"] = "True"
         # replace reset resolution from avalon core to pype's
-        self.reset_resolution()
+        #self.reset_resolution()
         # replace reset resolution from avalon core to pype's
         self.reset_frame_range_handles()
         # add colorspace menu item

--- a/openpype/version.py
+++ b/openpype/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """Package declaring Pype version."""
 
-__version__ = "staging/3.16.9-quad-1.11.2-bypass-resolution-reset"
+__version__ = "3.16.9-quad-1.11.2-bypass-resolution-reset"

--- a/openpype/version.py
+++ b/openpype/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """Package declaring Pype version."""
 
-__version__ = "3.16.9-quad-1.11.2"
+__version__ = "staging/3.16.9-quad-1.11.2-bypass-resolution-reset"


### PR DESCRIPTION
Staging for Wizz with : 
- Base 3.16.9-quad.1.12.0
- https://github.com/quadproduction/issues/issues/402
- https://github.com/quadproduction/issues/issues/419