### PR TITLE
[Nuke][BuildTemplateFromWorkfile] Allows Transition between legacy creators and new one

### DIFF
--- a/openpype/hosts/nuke/api/workfile_template_builder.py
+++ b/openpype/hosts/nuke/api/workfile_template_builder.py
@@ -106,7 +106,11 @@ class NukePlaceholderPlugin(PlaceholderPlugin):
 
     def _parse_placeholder_node_data(self, node):
         placeholder_data = {}
-        for key in self.get_placeholder_keys():
+        # Allow the transition between legacy Creator and New one
+        placeholder_keys = self.get_placeholder_keys()
+        # TODO: Delete this once all the templates will used 'Create' instead of 'Creator' plugins
+        placeholder_keys.add("creator")
+        for key in placeholder_keys:
             knob = node.knob(key)
             value = None
             if knob is not None:
@@ -559,6 +563,11 @@ class NukePlaceholderCreatePlugin(
         if "nb_children" in node_knobs:
             nb_children = int(node_knobs["nb_children"].getValue())
         placeholder_data["nb_children"] = nb_children
+
+        # TODO: Delete this once all the templates will used 'Create' instead of 'Creator' plugins
+        if "creator" in placeholder_data:
+            placeholder_data["create"] = placeholder_data["creator"]
+            del placeholder_data['creator']
 
         siblings = []
         if "siblings" in node_knobs:

--- a/openpype/pipeline/workfile/workfile_template_builder.py
+++ b/openpype/pipeline/workfile/workfile_template_builder.py
@@ -1751,9 +1751,9 @@ class PlaceholderCreateMixin(object):
             attribute_definitions.UISeparatorDef(),
 
             attribute_definitions.EnumDef(
-                "creator",
-                label="Creator",
-                default=options.get("creator"),
+                "create",
+                label="Create",
+                default=options.get("create"),
                 items=creator_items,
                 tooltip=(
                     "Creator"
@@ -1801,9 +1801,8 @@ class PlaceholderCreateMixin(object):
         """
 
         legacy_create = self.builder.use_legacy_creators
-        creator_name = placeholder.data["creator"]
+        creator_name = placeholder.data["create"]
         create_variant = placeholder.data["create_variant"]
-
         creator_plugin = self.builder.get_creators_by_name()[creator_name]
 
         # create subset name
@@ -1953,7 +1952,7 @@ class CreatePlaceholderItem(PlaceholderItem):
             "Failed to create {} instance using Creator {}"
         ).format(
             len(self._failed_created_publish_instances),
-            self.data["creator"]
+            self.data["create"]
         )
         return [message]
 


### PR DESCRIPTION
## Changelog Description
Déploiement d'un fix permettant la lecture des anciens plugins 'Creator' au moment du Build, cependant la création n'autorise désormais que la création des nouveaux plugins càd du type 'Create'.

La transition se fera ainsi dans le temps sans impacter les anciennes prods ni les nouvelles.