### PR TITLE
Fix: error when opening the publish window if a renderlayer has been renamed

### DIFF
--- a/openpype/hosts/maya/api/plugin.py
+++ b/openpype/hosts/maya/api/plugin.py
@@ -524,9 +524,9 @@ class RenderlayerCreator(NewCreator, MayaCreatorBase):
         # Rename the set to match the new layer name
         set_layer_name = node.split(":")[-1]
         new_set_name = node.replace(set_layer_name, layer_name)
-        cmds.rename(node, new_set_name)
+        renamed_node = cmds.rename(node, new_set_name)
 
-        return node
+        return renamed_node
 
     def _create_layer_instance_node(self, layer):
         # We only collect if a CreateRender instance exists


### PR DESCRIPTION
## Changelog Description
Fix the error by returning the correct renamed node.

## Testing notes:
1. create a renderlayer instance
2. rename the layer in the maya render setup editor
3. open the publish window
4. there's shouldn't be any error
5. the Renderlayer, Subset, and Variant extra attribute should be updated
