### PR TITLE
bugfix: 476: ajout d'un tag pour gérer les single frame

### DIFF
--- a/openpype/plugins/publish/extract_review.py
+++ b/openpype/plugins/publish/extract_review.py
@@ -205,7 +205,8 @@ class ExtractReview(pyblish.api.InstancePlugin):
                 or (single_frame_image and frame_filter == "multi_frame")
             ):
                 continue
-
+            #add the frame_filter as a tag for the integrate_kitsu_sequence to handle single_frame
+            output_def['tags'].append(frame_filter)
             filtered_defs.append(output_def)
 
         return filtered_defs


### PR DESCRIPTION
Fix quadproduction/issues#476
## Changelog Description
Ajout d'un tag pour gérer les single frame dans les review/burins
