### PR TITLE
bugfix: 382: Fix le pbl de clé manquante lors du clean de frame_refer…

### DIFF
--- a/openpype/hosts/tvpaint/lib.py
+++ b/openpype/hosts/tvpaint/lib.py
@@ -260,9 +260,9 @@ def _cleanup_frame_references(output_idx_by_frame_idx):
         real_reference_idx = reference_idx
         _tmp_reference_idx = reference_idx
         while True:
-            #to avoid not finding key (outside the range) we make a get
             _temp = output_idx_by_frame_idx.get(_tmp_reference_idx)
             if not _temp:
+                # Key outside the range, skip
                 break
             if _temp == _tmp_reference_idx:
                 real_reference_idx = _tmp_reference_idx

--- a/openpype/hosts/tvpaint/lib.py
+++ b/openpype/hosts/tvpaint/lib.py
@@ -179,6 +179,9 @@ def _calculate_in_range_frames(
     # Calculate in range frames
     in_range_frames = []
     for frame_idx in exposure_frames:
+        # if the range_start is in between 2 exposure frame
+        if range_start > frame_idx:
+            output_idx_by_frame_idx[range_start] = frame_idx
         if range_start <= frame_idx <= range_end:
             output_idx_by_frame_idx[frame_idx] = frame_idx
             in_range_frames.append(frame_idx)
@@ -257,7 +260,10 @@ def _cleanup_frame_references(output_idx_by_frame_idx):
         real_reference_idx = reference_idx
         _tmp_reference_idx = reference_idx
         while True:
-            _temp = output_idx_by_frame_idx[_tmp_reference_idx]
+            #to avoid not finding key (outside the range) we make a get
+            _temp = output_idx_by_frame_idx.get(_tmp_reference_idx)
+            if not _temp:
+                break
             if _temp == _tmp_reference_idx:
                 real_reference_idx = _tmp_reference_idx
                 break


### PR DESCRIPTION
…ence et la récupération de frame d'exposition au cas où le IN est situé entre 2 frame d'exposition
Fix quadproduction/issues#382

## Changelog Description
Permet de ne pas bloquer lors du clean de frame reference, au cas où la frame d'exposition utilisée n'est pas inclut dans le frame range voulant être exporté.
Fix aussi le bug qui empêché l'export de frame au cas où le IN était situé entre 2 frames d'expositions

