### PR TITLE
#379: enhancement: add button to update representations availabilitie…

### DIFF
--- a/openpype/modules/sync_server/sync_server.py
+++ b/openpype/modules/sync_server/sync_server.py
@@ -292,7 +292,7 @@ class SyncServerThread(threading.Thread):
     """
     def __init__(self, module):
         self.log = Logger.get_logger(self.__class__.__name__)
-
+        self.log.setLevel(Logger.WRN)
         super(SyncServerThread, self).__init__()
         self.module = module
         self.loop = None


### PR DESCRIPTION
…s in loader

## Changelog Description
Add button to check representations availabilities in loader.

## Additional info
By default, the information of availability is linked to the user. That means that it is only updated when the user download a given representation. The side effect with this behavior is that when the project sync is set to use Studio or Local (with target to shared server), it will always show an unavailable representation, even if the file is at the given location and accessible.

This button is aimed to retrieve all representations of a given project and to check for file availability for each of them.

## Testing notes:
1. Open loader
2. Select project
3. Click on `update availability` button
