### PR TITLE
#499: bugfix: manually set imported module from python3 dirpath if lo…

### DIFF
--- a/openpype/lib/python_module_tools.py
+++ b/openpype/lib/python_module_tools.py
@@ -195,8 +195,20 @@ def _import_module_from_dirpath_py3(dirpath, module_name, dst_module_name):
 
     sys.modules[full_module_name] = module
 
-    # Execute module import
-    loader.exec_module(module)
+    try:
+        # Execute module import
+        loader.exec_module(module)
+
+    except:
+        # In specific cases, module_name needs to be explicitely defined
+        # as it is not automatically retrieved by the module import.
+        # Therefore, we manually add origin and submodule search locations if previous
+        # loader has not loaded, by reusing given dirpath with added informations.
+        spec.origin=f'{dirpath}{module_name}\\__init__.py'
+        spec.submodule_search_locations=[f'{dirpath}\\{module_name}']
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full_module_name] = module
+        loader.exec_module(module)
 
     return module
 

--- a/openpype/lib/python_module_tools.py
+++ b/openpype/lib/python_module_tools.py
@@ -207,6 +207,8 @@ def _import_module_from_dirpath_py3(dirpath, module_name, dst_module_name):
         spec.origin=f'{dirpath}{module_name}\\__init__.py'
         spec.submodule_search_locations=[f'{dirpath}\\{module_name}']
         module = importlib.util.module_from_spec(spec)
+        if dst_module is not None:
+            setattr(dst_module, module_name, module)
         sys.modules[full_module_name] = module
         loader.exec_module(module)
 


### PR DESCRIPTION
…ading failed

## Changelog Description
Manually set module specifications when python 3 imported modules loading fails. Solve an issue with custom plugins loading when opening a scene with Blender 4.1.

## Testing notes:
1. Open any scene with Blender 4.1
2. Check that custom plugins has been correctly imported (loaders, publishers, ...)
