### PR TITLE
521: enhancement: Cropper tous les layers à la taille du canva lors d'un publish

### DIFF
--- a/openpype/hosts/photoshop/api/extension/client/client.js
+++ b/openpype/hosts/photoshop/api/extension/client/client.js
@@ -155,6 +155,28 @@
                   });
       });
 
+      RPC.addRoute('Photoshop.get_activeDocument_format_resolution', function (data) {
+        log.warn('Server called client route ' +
+                 '"get_activeDocument_format_resolution":', data);
+        return runEvalScript("getActiveDocumentFormatResolution()")
+            .then(function(result){
+                log.warn("Get document resolution ");
+                return result;
+            });
+        });
+
+    RPC.addRoute('Photoshop.crop_document_to_coordinate', function (data) {
+            log.warn('Server called client route "crop_document_to_coordinate":', data);
+            return runEvalScript("cropDocumentToCoordinate('" + data.x1 +"', " +
+                                                      "'"+ data.y1 +"',"+
+                                                      "'"+ data.x2 +"'," +
+                                                      "'"+ data.y2 +"'," +")")
+                .then(function(result){
+                    log.warn("Crop to given coordinates");
+                    return result;
+                });
+        });
+
       RPC.addRoute('Photoshop.save', function (data) {
               log.warn('Server called client route "save":', data);
 

--- a/openpype/hosts/photoshop/api/extension/host/index.jsx
+++ b/openpype/hosts/photoshop/api/extension/host/index.jsx
@@ -263,6 +263,42 @@ function getActiveDocumentFullName(){
     };
 }
 
+function getActiveDocumentFormatResolution(){
+    /**
+     *   Returns a dict with the resolution dimenssion of the current doc
+     * */
+    if (documents.length == 0){
+        return null;
+    }
+
+    try {
+        savedUnit = app.preferences.rulerUnits;
+        app.preferences.rulerUnits = Units.PIXELS;
+        resDict = {"width" :app.activeDocument.width.value,
+                    "height": app.activeDocument.height.value}
+        app.preferences.rulerUnits = savedUnit;
+        return(JSON.stringify(resDict));
+    }catch(e){
+        // No doc is active.
+        return
+    };
+}
+
+function cropDocumentToCoordinate(x1, y1, x2, y2) {
+    /*
+    * Crop all the document and the layers in to the define coordinate
+    * x1,y1----------------------
+    * |                         |
+    * |                         |
+    * |                         |
+    * |                         |
+    * ----------------------x2,y2
+    */
+    bounds = [UnitValue(x1, "px"), UnitValue(y1, "px"), UnitValue(x2, "px"), UnitValue(y2, "px")];
+    app.activeDocument.crop(bounds);
+}
+
+
 function imprint(payload){
     /**
      *  Sets headline content of current document with metadata. Stores

--- a/openpype/hosts/photoshop/api/extension/host/index.jsx
+++ b/openpype/hosts/photoshop/api/extension/host/index.jsx
@@ -265,10 +265,10 @@ function getActiveDocumentFullName(){
 
 function getActiveDocumentFormatResolution(){
     /**
-     *   Returns a dict with the resolution dimenssion of the current doc
+     *   Returns a dict with the resolution of the current doc
      * */
     if (documents.length == 0){
-        return null;
+        return {};
     }
 
     try {
@@ -280,7 +280,7 @@ function getActiveDocumentFormatResolution(){
         return(JSON.stringify(resDict));
     }catch(e){
         // No doc is active.
-        return
+        return {}
     };
 }
 

--- a/openpype/hosts/photoshop/api/ws_stub.py
+++ b/openpype/hosts/photoshop/api/ws_stub.py
@@ -364,13 +364,14 @@ class PhotoshopServerStub:
         """Return the width and height in pixel of the active doc
 
         Returns(dict):
-            {"width": int, "height": int}
+            {"width": int, "height": int} or empty dict {} if document size isn't valid
         """
         res = self.websocketserver.call(
             self.client.call('Photoshop.get_activeDocument_format_resolution')
         )
-
-        return json.loads(res)
+        if res:
+            return json.loads(res)
+        return {}
 
     def crop_document_to_coordinate(self, x1, y1, x2, y2):
         """Crop the active document to the given coordinates

--- a/openpype/hosts/photoshop/api/ws_stub.py
+++ b/openpype/hosts/photoshop/api/ws_stub.py
@@ -360,6 +360,36 @@ class PhotoshopServerStub:
             )
         )
 
+    def get_activeDocument_format_resolution(self):
+        """Return the width and height in pixel of the active doc
+
+        Returns(dict):
+            {"width": int, "height": int}
+        """
+        res = self.websocketserver.call(
+            self.client.call('Photoshop.get_activeDocument_format_resolution')
+        )
+
+        return json.loads(res)
+
+    def crop_document_to_coordinate(self, x1, y1, x2, y2):
+        """Crop the active document to the given coordinates
+        x1,y1----------------------
+        |                         |
+        |                         |
+        |                         |
+        |                         |
+        ----------------------x2,y2
+        Returns: None
+        """
+        self.websocketserver.call(
+            self.client.call('Photoshop.crop_document_to_coordinate',
+                             x1=x1,
+                             y1=y1,
+                             x2=x2,
+                             y2=y2)
+        )
+
     def get_active_document_full_name(self):
         """Returns full name with path of active document via ws call
 


### PR DESCRIPTION
Fix quadproduction/issues#521

## Changelog Description
Ajout d'une fonction pour recupérer les dimensions du doc actif et une autre pour crop tous les layers selon des coordonées

