### PR TITLE
Replace ExManCmd by Zxp Extractor & Add --zxp-ignore-update Flag

### DIFF
--- a/igniter/__init__.py
+++ b/igniter/__init__.py
@@ -84,6 +84,7 @@ def open_update_window(openpype_version, zxp_hosts=None):
 
     if not is_event_loop_running:
         app.exec_()
+        app.shutdown()
     else:
         d.exec_()
 

--- a/igniter/bootstrap_repos.py
+++ b/igniter/bootstrap_repos.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import sys
 import tempfile
-import subprocess
+import zipfile
 from pathlib import Path
 from typing import Union, Callable, List, Tuple
 import hashlib
@@ -1482,9 +1482,7 @@ class BootstrapRepos:
 
         return path_prog_folder.joinpath("MacOS", "ExManCmd")
 
-    def extract_zxp_info_from_manifest(self, openpype_version: OpenPypeVersion, host_id: str):
-        version_path = openpype_version.path
-        path_manifest = version_path.joinpath("openpype", "hosts", host_id, "api", "extension", "CSXS", "manifest.xml")
+    def extract_zxp_info_from_manifest(self, path_manifest: Path):
         pattern_regex_extension_id = r"ExtensionBundleId=\"(?P<extension_id>[\w.]+)\""
         pattern_regex_extension_version = r"ExtensionBundleVersion=\"(?P<extension_version>[\d.]+)\""
 
@@ -1509,29 +1507,21 @@ class BootstrapRepos:
         return extension_id, extension_version
 
     def update_zxp_extensions(self, openpype_version: OpenPypeVersion, extensions: [ZXPExtensionData]):
-        # Check the current OS
-        low_platform = platform.system().lower()
-        if not extensions or platform.system().lower() == "linux":
-            # No host in array or user is on Linux, the platform doesn't support Adobe softwares
-            return
+        # Determine the user-specific Adobe extensions directory
+        user_extensions_dir = Path(os.getenv('APPDATA'), 'Adobe', 'CEP', 'extensions')
+
+        # Create the user extensions directory if it doesn't exist
+        os.makedirs(user_extensions_dir, exist_ok=True)
 
         version_path = openpype_version.path
-
-        path_prog = self._get_zxp_handler_program_path(low_platform)
-        if low_platform == "windows":
-            cmd_arg_prefix = "/"
-            creation_flags = subprocess.CREATE_NO_WINDOW
-        else:
-            cmd_arg_prefix = "--"
-            creation_flags = 0  # No need to specify on non-Windows platforms
 
         for extension in extensions:
             # Remove installed ZXP extension
             if self._step_text_signal:
                 self._step_text_signal.emit("Removing installed ZXP extension for "
                                             "<b>{}</b> ...".format(extension.host_id))
-            subprocess.run([str(path_prog), "{}remove".format(cmd_arg_prefix), extension.id],
-                           stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, creationflags=creation_flags)
+            if user_extensions_dir.joinpath(extension.host_id).exists():
+                shutil.rmtree(user_extensions_dir.joinpath(extension.host_id))
 
             # Install ZXP shipped in the current version folder
             fullpath_curr_zxp_extension = version_path.joinpath("openpype",
@@ -1547,15 +1537,18 @@ class BootstrapRepos:
 
             if self._step_text_signal:
                 self._step_text_signal.emit("Install ZXP extension for <b>{}</b> ...".format(extension.host_id))
-            completed_process = subprocess.run([str(path_prog), "{}install".format(cmd_arg_prefix),
-                                                str(fullpath_curr_zxp_extension)], capture_output=True,
-                                               creationflags=creation_flags)
-            if completed_process.returncode != 0 or completed_process.stderr:
-                if self._log_signal:
-                    self._log_signal.emit("Couldn't install the ZXP extension for {} "
-                                          "due to an error: full log: {}\n{}".format(extension.host_id,
-                                                                                     completed_process.stdout,
-                                                                                     completed_process.stderr), True)
+
+            # Copy zxp into APPDATA user folder
+            shutil.copy2(fullpath_curr_zxp_extension, user_extensions_dir)
+            extracted_folder = Path(user_extensions_dir, extension.id)
+            zip_path = Path(user_extensions_dir, 'extension.zxp')
+
+            # Extract the .zxp file
+            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                zip_ref.extractall(extracted_folder)
+
+            # Cleaned up temporary files removed zip_path
+            os.remove(zip_path)
 
     def get_zxp_extensions_to_update(self, openpype_version, system_settings, force=False) -> [ZXPExtensionData]:
         # List of all Adobe software ids (named hosts) handled by OpenPype
@@ -1564,41 +1557,22 @@ class BootstrapRepos:
 
         zxp_hosts_to_update = []
 
-        # Check the current OS
-        low_platform = platform.system().lower()
-        if low_platform == "linux":
-            # The platform doesn't support Adobe softwares
-            return zxp_hosts_to_update
-
-        path_prog = self._get_zxp_handler_program_path(low_platform)
-        if low_platform == "windows":
-            cmd_arg_prefix = "/"
-            creation_flags = subprocess.CREATE_NO_WINDOW
-        else:
-            cmd_arg_prefix = "--"
-            creation_flags = 0
-
-        # Get installed extensions
-        completed_process = subprocess.run([str(path_prog), "{}list".format(cmd_arg_prefix), "all"],
-                                           capture_output=True, creationflags=creation_flags)
-        installed_extensions_info = completed_process.stdout
+        # Determine the user-specific Adobe extensions directory
+        user_extensions_dir = Path(os.getenv('APPDATA'), 'Adobe', 'CEP', 'extensions')
 
         zxp_hosts_to_update = []
         for zxp_host_id in zxp_host_ids:
-            extension_id, extension_new_version = self.extract_zxp_info_from_manifest(openpype_version, zxp_host_id)
-            if not extension_id or not extension_new_version:
+            version_path = openpype_version.path
+            path_manifest = version_path.joinpath("openpype", "hosts", zxp_host_id, "api", "extension", "CSXS",
+                                                  "manifest.xml")
+            extension_new_id, extension_new_version = self.extract_zxp_info_from_manifest(path_manifest)
+            if not extension_new_id or not extension_new_version:
                 # ZXP extension seems invalid or doesn't exists for this software, skipping
                 continue
 
-            extension_curr_version = ""
-
+            cur_manifest = user_extensions_dir.joinpath(extension_new_id, "CSXS", "manifest.xml")
             # Get the installed version
-            escaped_extension_id_str = extension_id.replace(".", "\.")  # noqa
-            pattern_regex_extension_version = fr"{escaped_extension_id_str}\s+(?P<version>[\d.]+)"
-
-            match_extension = re.search(pattern_regex_extension_version, str(installed_extensions_info))
-            if match_extension:
-                extension_curr_version = semver.VersionInfo.parse(match_extension.group("version"))
+            extension_cur_id, extension_curr_version = self.extract_zxp_info_from_manifest(cur_manifest)
 
             if not force:
                 # Is the update required?
@@ -1614,7 +1588,7 @@ class BootstrapRepos:
                     continue
 
             zxp_hosts_to_update.append(ZXPExtensionData(zxp_host_id,
-                                                        extension_id,
+                                                        extension_new_id,
                                                         extension_curr_version,
                                                         extension_new_version))
 

--- a/openpype/modules/update_zxp_extensions_action.py
+++ b/openpype/modules/update_zxp_extensions_action.py
@@ -20,6 +20,8 @@ class UpdateZXPExtensionsAction(OpenPypeModule, ITrayAction):
         self.enabled = True
         if AYON_SERVER_ENABLED:
             self.enabled = False
+        if os.getenv("OPENPYPE_IGNORE_ZXP"):
+            self.enabled = False
 
     def tray_init(self):
         return

--- a/openpype/modules/update_zxp_extensions_action.py
+++ b/openpype/modules/update_zxp_extensions_action.py
@@ -20,7 +20,7 @@ class UpdateZXPExtensionsAction(OpenPypeModule, ITrayAction):
         self.enabled = True
         if AYON_SERVER_ENABLED:
             self.enabled = False
-        if os.getenv("OPENPYPE_IGNORE_ZXP"):
+        if os.getenv("OPENPYPE_IGNORE_ZXP_UPDATE"):
             self.enabled = False
 
     def tray_init(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,14 +170,6 @@ hash = "3894dec7e4e521463891a869586850e8605f5fd604858b674c87323bf33e273d"
 url = "https://distribute.openpype.io/thirdparty/OpenColorIO-Configs-1.0.2.zip"
 hash = "4ac17c1f7de83465e6f51dd352d7117e07e765b66d00443257916c828e35b6ce"
 
-[openpype.thirdparty.ex_man_cmd.windows]
-url = "https://github.com/quadproduction/ex_man_cmd/releases/download/1.0.0/ex_man_cmd-windows.zip"
-hash = "65ce0d60ac63df8f13c0a1b872b0db15c08f31649cdfdf9940ebba38b18e845c"
-
-[openpype.thirdparty.ex_man_cmd.darwin]
-url = "https://github.com/quadproduction/ex_man_cmd/releases/download/1.0.0/ex_man_cmd-macos.zip"
-hash = "3f758601b4664ed1b41835236050ee2799fcced5673a7b5b4ce9922a7cb79136"
-
 [tool.pyright]
 include = [
     "igniter",

--- a/start.py
+++ b/start.py
@@ -196,10 +196,10 @@ else:
     os.environ["SSL_CERT_FILE"] = ssl_cert_file
 
 if "--zxp-ignore-update" in sys.argv:
-    os.environ["OPENPYPE_IGNORE_ZXP"] = "1"
+    os.environ["OPENPYPE_IGNORE_ZXP_UPDATE"] = "1"
     sys.argv.remove("--zxp-ignore-update")
-elif os.getenv("OPENPYPE_IGNORE_ZXP") != "1":
-    os.environ.pop("OPENPYPE_IGNORE_ZXP", None)
+elif os.getenv("OPENPYPE_IGNORE_ZXP_UPDATE") != "1":
+    os.environ.pop("OPENPYPE_IGNORE_ZXP_UPDATE", None)
 
 
 if "--headless" in sys.argv:
@@ -1193,7 +1193,7 @@ def boot():
     set_openpype_global_environments()
     _print("  - for modules ...")
     set_modules_environments()
-    if os.getenv("OPENPYPE_IGNORE_ZXP"):
+    if os.getenv("OPENPYPE_IGNORE_ZXP_UPDATE"):
         _print(">>> skip ZXP extensions ...")
     else:
         _print(">>> check ZXP extensions ...")

--- a/start.py
+++ b/start.py
@@ -195,6 +195,13 @@ else:
     ssl_cert_file = certifi.where()
     os.environ["SSL_CERT_FILE"] = ssl_cert_file
 
+if "--zxp-ignore-update" in sys.argv:
+    os.environ["OPENPYPE_IGNORE_ZXP"] = "1"
+    sys.argv.remove("--zxp-ignore-update")
+elif os.getenv("OPENPYPE_IGNORE_ZXP") != "1":
+    os.environ.pop("OPENPYPE_IGNORE_ZXP", None)
+
+
 if "--headless" in sys.argv:
     os.environ["OPENPYPE_HEADLESS_MODE"] = "1"
     sys.argv.remove("--headless")
@@ -1186,8 +1193,11 @@ def boot():
     set_openpype_global_environments()
     _print("  - for modules ...")
     set_modules_environments()
-    _print(">>> check ZXP extensions ...")
-    update_zxp_extensions(openpype_version)
+    if os.getenv("OPENPYPE_IGNORE_ZXP"):
+        _print(">>> skip ZXP extensions ...")
+    else:
+        _print(">>> check ZXP extensions ...")
+        update_zxp_extensions(openpype_version)
 
     assert openpype_version, "Version path not defined."
 


### PR DESCRIPTION
## Changelog Description
- Add the posibility to ignore zxp update with this flag `--zxp-ignore-update`
- Replace ExManCmd by Extract Zxp into AppData User (Automatically detected by Adobe and does not need admin right)
- Fix QApplication instance already running when zxp windows are crashing